### PR TITLE
DataFrame#vectors= should change the name of the vectors in `@data`.

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1356,6 +1356,9 @@ module Daru
       end
 
       @vectors = new_index
+      @data.zip(new_index.to_a).each do |vect, name|
+        vect.name = name
+      end
       self
     end
 

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2594,6 +2594,13 @@ describe Daru::DataFrame do
         @df.vectors = Daru::Index.new([1,2,'3',4,'5'])
       }.to raise_error(ArgumentError)
     end
+
+    it "change name of vectors in @data" do
+      new_index_array = [:k, :l, :m]
+      @df.vectors = Daru::Index.new(new_index_array)
+
+      expect(@df.data.map { |vector| vector.name }).to eq(new_index_array)
+    end
   end
 
   context "#rename_vectors" do


### PR DESCRIPTION
`DataFrame#vectors=` changes `@vectors` variable, however, the name of the vectors in `@data` is not changed.

```ruby
irb(main):002:0> df = Daru::DataFrame.new(a: [1,2,3])
=> #<Daru::DataFrame(3x1)>
       a
   0   1
   1   2
   2   3
irb(main):004:0> df.vectors = Daru::Index.new [:b]
irb(main):005:0> df
=> #<Daru::DataFrame(3x1)>
       b
   0   1
   1   2
   2   3
irb(main):006:0> df[:b]
=> #<Daru::Vector(3)>
       a
   0   1
   1   2
   2   3
```

`DataFrame#vectors=` should change the name of vectors in `@data`.