### PR TITLE
Add imagemagick in daru development guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ To install dependencies, execute the following commands:
 *  `sudo apt-get update -qq`
 *  `sudo apt-get install -y libgsl0-dev r-base r-base-dev`
 *  `sudo Rscript -e "install.packages(c('Rserve','irr'),,'http://cran.us.r-project.org')"`
+*  `sudo apt-get install libmagickwand-dev imagemagick`
 
 
 Then install remaining dependencies:


### PR DESCRIPTION
In order to install rmagick gem (dependency for daru) I had to execute the following command

`sudo apt-get install libmagickwand-dev imagemagick`

I think it will be good to be added it in the contributing guide.