### PR TITLE
Adds support to missing data for where clause

### DIFF
--- a/lib/daru/core/query.rb
+++ b/lib/daru/core/query.rb
@@ -39,7 +39,7 @@ module Daru
 
       class << self
         def apply_scalar_operator operator, data, other
-          BoolArray.new data.map { |d| !!d.send(operator, other) }
+          BoolArray.new data.map { |d| !!d.send(operator, other) unless d.nil? }
         end
 
         def apply_vector_operator operator, vector, other

--- a/lib/daru/core/query.rb
+++ b/lib/daru/core/query.rb
@@ -39,7 +39,7 @@ module Daru
 
       class << self
         def apply_scalar_operator operator, data, other
-          BoolArray.new data.map { |d| !!d.send(operator, other) unless d.nil? }
+          BoolArray.new data.map { |d| !!d.send(operator, other) unless MISSING_VALUES.include? d }
         end
 
         def apply_vector_operator operator, vector, other

--- a/spec/core/query_spec.rb
+++ b/spec/core/query_spec.rb
@@ -267,10 +267,9 @@ describe "Arel-like syntax" do
           ).to eq(answer)
       end
 
-      let(:dv1) { Daru::Vector.new([1,11,32,Float::NAN,nil]) }
-      let(:dv2) { Daru::Vector.new([1,11]) }
+      let(:dv) { Daru::Vector.new([1,11,32,Float::NAN,nil]) }
       it "handles empty data" do
-        expect(dv1.where(dv1.lt(14))).to eq(dv2)
+        expect(dv.where(dv.lt(14))).to eq(Daru::Vector.new([1,11]))
       end
 
       it "does not give SystemStackError" do

--- a/spec/core/query_spec.rb
+++ b/spec/core/query_spec.rb
@@ -240,9 +240,9 @@ describe "Arel-like syntax" do
     context Daru::DataFrame do
       before do
         @df = Daru::DataFrame.new({
-          number: [1,2,3,4,5,6],
-          sym: [:one, :two, :three, :four, :five, :six],
-          names: ['sameer', 'john', 'james', 'omisha', 'priyanka', 'shravan']
+          number: [1,2,3,4,5,6,nil],
+          sym: [:one, :two, :three, :four, :five, :six, :seven],
+          names: ['sameer', 'john', 'james', 'omisha', 'priyanka', 'shravan', Float::NAN.to_s]
         })
       end
 
@@ -267,6 +267,16 @@ describe "Arel-like syntax" do
           ).to eq(answer)
       end
 
+      it "handles empty data" do
+        answer = Daru::DataFrame.new({
+          number: [nil],
+          sym: [:seven],
+          names: [Float::NAN.to_s]
+          }, index: Daru::Index.new([6])
+        )
+        expect(@df.where(@df[:sym].eq(:seven))).to eq(answer)
+      end
+
       it "does not give SystemStackError" do
         v = Daru::Vector.new [1]*300_000
         expect { v.where v.eq(1) }.not_to raise_error
@@ -276,7 +286,7 @@ describe "Arel-like syntax" do
     context Daru::Vector do
       context "non-categorical type" do
         before do
-          @vector = Daru::Vector.new([2,5,1,22,51,4])
+          @vector = Daru::Vector.new([2,5,1,22,51,4,nil,Float::NAN])
         end
   
         it "accepts a simple single statement" do

--- a/spec/core/query_spec.rb
+++ b/spec/core/query_spec.rb
@@ -240,9 +240,9 @@ describe "Arel-like syntax" do
     context Daru::DataFrame do
       before do
         @df = Daru::DataFrame.new({
-          number: [1,2,3,4,5,6,nil],
+          number: [1,2,3,4,5,6,Float::NAN],
           sym: [:one, :two, :three, :four, :five, :six, :seven],
-          names: ['sameer', 'john', 'james', 'omisha', 'priyanka', 'shravan', Float::NAN.to_s]
+          names: ['sameer', 'john', 'james', 'omisha', 'priyanka', 'shravan',nil]
         })
       end
 
@@ -267,14 +267,10 @@ describe "Arel-like syntax" do
           ).to eq(answer)
       end
 
+      let(:dv1) { Daru::Vector.new([1,11,32,Float::NAN,nil]) }
+      let(:dv2) { Daru::Vector.new([1,11]) }
       it "handles empty data" do
-        answer = Daru::DataFrame.new({
-          number: [nil],
-          sym: [:seven],
-          names: [Float::NAN.to_s]
-          }, index: Daru::Index.new([6])
-        )
-        expect(@df.where(@df[:sym].eq(:seven))).to eq(answer)
+        expect(dv1.where(dv1.lt(14))).to eq(dv2)
       end
 
       it "does not give SystemStackError" do


### PR DESCRIPTION
Fixes issue #246. Sample output for the building pass is shown below.

```
2.3.1 :002 > v= Daru::Vector.new([1,2,3,Float::NAN, nil])
 => #<Daru::Vector(5)>
   0   1
   1   2
   2   3
   3 NaN
   4 nil 
2.3.1 :003 > v.where(v.lt(4))

 => #<Daru::Vector(3)>
   0   1
   1   2
   2   3 
2.3.1 :004 > v.where(v.lt(2))

 => #<Daru::Vector(1)>
   0   1 
2.3.1 :005 > v.where(v.lt(3))

 => #<Daru::Vector(2)>
   0   1
   1   2 
2.3.1 :006 > v.where(v.gt(1))

 => #<Daru::Vector(2)>
   1   2
   2   3 
```

Ping @v0dro @zverok @lokeshh - Please review this PR when you're free. :smile: 