### PR TITLE
fix require stucture

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,3 +67,41 @@ def run *cmd
   sh(cmd.join(" "))
 end
 
+# return error string or false
+def require_error?(filename)
+  require 'open3'
+
+  lib_dir = File.expand_path("../lib", __FILE__)
+  cmd = ['ruby', '-I', lib_dir, "#{lib_dir}/#{filename}"]
+  # does this behave differently?
+  # cmd = ['ruby', '-I', lib_dir, '-r', filename, '-e', "':ok'"]
+
+  _in, out, wait_thr = Open3.popen2e(*cmd)
+  if wait_thr.value.exitstatus == 0
+    false
+  else
+    out.gets.to_s.chomp
+  end
+end
+
+task :modular_require do
+  errors = []
+  Dir.chdir lib_folder
+  Dir['**/*.rb'].each { |lib_file|
+    error = require_error?(lib_file)
+    if error
+      result = 'ERROR'
+      errors << error
+    else
+      result = '   OK'
+    end
+    puts [result, lib_file].join(' ')
+  }
+  unless errors.empty?
+    puts
+    puts "ERRORS"
+    puts "---"
+    puts errors
+    exit 1
+  end
+end

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -1,101 +1,10 @@
-# :nocov:
-def jruby?
-  RUBY_ENGINE == 'jruby'
-end
-# :nocov:
-
-module Daru
-  DAYS_OF_WEEK = {
-    'SUN' => 0,
-    'MON' => 1,
-    'TUE' => 2,
-    'WED' => 3,
-    'THU' => 4,
-    'FRI' => 5,
-    'SAT' => 6
-  }.freeze
-
-  MONTH_DAYS = {
-    1 => 31,
-    2 => 28,
-    3 => 31,
-    4 => 30,
-    5 => 31,
-    6 => 30,
-    7 => 31,
-    8 => 31,
-    9 => 30,
-    10 => 31,
-    11 => 30,
-    12 => 31
-  }.freeze
-
-  MISSING_VALUES = [nil, Float::NAN].freeze
-
-  @lazy_update = false
-
-  SPLIT_TOKEN = ','.freeze
-
-  @plotting_library = :nyaplot
-
-  class << self
-    # A variable which will set whether Vector metadata is updated immediately or lazily.
-    # Call the #update method every time a values are set or removed in order to update
-    # metadata like positions of missing values.
-    attr_accessor :lazy_update
-    attr_reader :plotting_library
-
-    def create_has_library(library)
-      lib_underscore = library.to_s.tr('-', '_')
-      define_singleton_method("has_#{lib_underscore}?") do
-        cv = "@@#{lib_underscore}"
-        unless class_variable_defined? cv
-          begin
-            library = 'nmatrix/nmatrix' if library == :nmatrix
-            require library.to_s
-            class_variable_set(cv, true)
-          rescue LoadError
-            # :nocov:
-            class_variable_set(cv, false)
-            # :nocov:
-          end
-        end
-        class_variable_get(cv)
-      end
-    end
-
-    def plotting_library= lib
-      case lib
-      when :gruff, :nyaplot
-        @plotting_library = lib
-      else
-        raise ArgumentError, "Unsupported library #{lib}"
-      end
-    end
-  end
-
-  create_has_library :gsl
-  create_has_library :nmatrix
-  create_has_library :nyaplot
-  create_has_library :gruff
-end
-
-[['reportbuilder', '~>1.4'], ['spreadsheet', '~>1.1.1']].each do |lib|
-  begin
-    gem lib[0], lib[1]
-    require lib[0]
-  rescue LoadError
-    STDERR.puts "\nInstall the #{lib[0]} gem version #{lib[1]} for using"\
-    " #{lib[0]} functions."
-  end
-end
-
 autoload :CSV, 'csv'
 require 'matrix'
 require 'forwardable'
 require 'erb'
 require 'date'
 
+require 'daru/platform.rb'
 require 'daru/version.rb'
 
 require 'daru/index/index.rb'

--- a/lib/daru/accessors/array_wrapper.rb
+++ b/lib/daru/accessors/array_wrapper.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Daru
   module Accessors
     # Internal class for wrapping ruby array

--- a/lib/daru/accessors/gsl_wrapper.rb
+++ b/lib/daru/accessors/gsl_wrapper.rb
@@ -1,3 +1,5 @@
+require 'daru/platform'
+
 if Daru.has_gsl?
   module Daru
     module Accessors

--- a/lib/daru/accessors/nmatrix_wrapper.rb
+++ b/lib/daru/accessors/nmatrix_wrapper.rb
@@ -1,3 +1,5 @@
+require 'daru/platform'
+
 if Daru.has_nmatrix?
   module Daru
     module Accessors

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1,3 +1,4 @@
+require 'daru/platform.rb'
 require 'daru/accessors/dataframe_by_row.rb'
 require 'daru/maths/arithmetic/dataframe.rb'
 require 'daru/maths/statistics/dataframe.rb'
@@ -9,7 +10,6 @@ module Daru
   class DataFrame # rubocop:disable Metrics/ClassLength
     include Daru::Maths::Arithmetic::DataFrame
     include Daru::Maths::Statistics::DataFrame
-    # TODO: Remove this line but its causing erros due to unkown reason
     include Daru::Plotting::DataFrame::NyaplotLibrary if Daru.has_nyaplot?
     extend Gem::Deprecate
 

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -1,3 +1,7 @@
+require 'daru/platform'
+require 'daru/date_time/offsets'
+require 'daru/index/index'
+
 module Daru
   # Private module for storing helper functions for DateTimeIndex.
   # @private

--- a/lib/daru/date_time/offsets.rb
+++ b/lib/daru/date_time/offsets.rb
@@ -1,6 +1,31 @@
 module Daru
   # rubocop:disable Style/OpMethod
 
+  DAYS_OF_WEEK = {
+    'SUN' => 0,
+    'MON' => 1,
+    'TUE' => 2,
+    'WED' => 3,
+    'THU' => 4,
+    'FRI' => 5,
+    'SAT' => 6
+  }.freeze
+
+  MONTH_DAYS = {
+    1 => 31,
+    2 => 28,
+    3 => 31,
+    4 => 30,
+    5 => 31,
+    6 => 30,
+    7 => 31,
+    8 => 31,
+    9 => 30,
+    10 => 31,
+    11 => 30,
+    12 => 31
+  }.freeze
+
   # Generic class for generating date offsets.
   class DateOffset
     # A Daru::DateOffset object is created by a passing certain options

--- a/lib/daru/index/categorical_index.rb
+++ b/lib/daru/index/categorical_index.rb
@@ -1,3 +1,5 @@
+require 'daru/index/index'
+
 module Daru
   class CategoricalIndex < Index
     # Create a categorical index object.

--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -1,3 +1,5 @@
+require 'daru/index/index'
+
 module Daru
   class MultiIndex < Index
     def each(&block)

--- a/lib/daru/platform.rb
+++ b/lib/daru/platform.rb
@@ -5,31 +5,6 @@ end
 # :nocov:
 
 module Daru
-  DAYS_OF_WEEK = {
-    'SUN' => 0,
-    'MON' => 1,
-    'TUE' => 2,
-    'WED' => 3,
-    'THU' => 4,
-    'FRI' => 5,
-    'SAT' => 6
-  }.freeze
-
-  MONTH_DAYS = {
-    1 => 31,
-    2 => 28,
-    3 => 31,
-    4 => 30,
-    5 => 31,
-    6 => 30,
-    7 => 31,
-    8 => 31,
-    9 => 30,
-    10 => 31,
-    11 => 30,
-    12 => 31
-  }.freeze
-
   MISSING_VALUES = [nil, Float::NAN].freeze
 
   @lazy_update = false

--- a/lib/daru/platform.rb
+++ b/lib/daru/platform.rb
@@ -1,0 +1,91 @@
+# :nocov:
+def jruby?
+  RUBY_ENGINE == 'jruby'
+end
+# :nocov:
+
+module Daru
+  DAYS_OF_WEEK = {
+    'SUN' => 0,
+    'MON' => 1,
+    'TUE' => 2,
+    'WED' => 3,
+    'THU' => 4,
+    'FRI' => 5,
+    'SAT' => 6
+  }.freeze
+
+  MONTH_DAYS = {
+    1 => 31,
+    2 => 28,
+    3 => 31,
+    4 => 30,
+    5 => 31,
+    6 => 30,
+    7 => 31,
+    8 => 31,
+    9 => 30,
+    10 => 31,
+    11 => 30,
+    12 => 31
+  }.freeze
+
+  MISSING_VALUES = [nil, Float::NAN].freeze
+
+  @lazy_update = false
+
+  SPLIT_TOKEN = ','.freeze
+
+  @plotting_library = :nyaplot
+
+  class << self
+    # A variable which will set whether Vector metadata is updated immediately or lazily.
+    # Call the #update method every time a values are set or removed in order to update
+    # metadata like positions of missing values.
+    attr_accessor :lazy_update
+    attr_reader :plotting_library
+
+    def create_has_library(library)
+      lib_underscore = library.to_s.tr('-', '_')
+      define_singleton_method("has_#{lib_underscore}?") do
+        cv = "@@#{lib_underscore}"
+        unless class_variable_defined? cv
+          begin
+            library = 'nmatrix/nmatrix' if library == :nmatrix
+            require library.to_s
+            class_variable_set(cv, true)
+          rescue LoadError
+            # :nocov:
+            class_variable_set(cv, false)
+            # :nocov:
+          end
+        end
+        class_variable_get(cv)
+      end
+    end
+
+    def plotting_library= lib
+      case lib
+      when :gruff, :nyaplot
+        @plotting_library = lib
+      else
+        raise ArgumentError, "Unsupported library #{lib}"
+      end
+    end
+  end
+
+  create_has_library :gsl
+  create_has_library :nmatrix
+  create_has_library :nyaplot
+  create_has_library :gruff
+end
+
+[['reportbuilder', '~>1.4'], ['spreadsheet', '~>1.1.1']].each do |lib|
+  begin
+    gem lib[0], lib[1]
+    require lib[0]
+  rescue LoadError
+    STDERR.puts "\nInstall the #{lib[0]} gem version #{lib[1]} for using"\
+    " #{lib[0]} functions."
+  end
+end

--- a/lib/daru/platform.rb
+++ b/lib/daru/platform.rb
@@ -44,7 +44,9 @@ module Daru
       when :gruff, :nyaplot
         @plotting_library = lib
       else
+        # :nocov:
         raise ArgumentError, "Unsupported library #{lib}"
+        # :nocov:
       end
     end
   end
@@ -55,12 +57,13 @@ module Daru
   create_has_library :gruff
 end
 
-[['reportbuilder', '~>1.4'], ['spreadsheet', '~>1.1.1']].each do |lib|
+[['reportbuilder', '~>1.4'], ['spreadsheet', '~>1.1.1']].each do |(lib,version)|
   begin
-    gem lib[0], lib[1]
-    require lib[0]
+    gem lib, version
+    require lib
   rescue LoadError
-    STDERR.puts "\nInstall the #{lib[0]} gem version #{lib[1]} for using"\
-    " #{lib[0]} functions."
+    # :nocov:
+    $stderr.puts "\nInstall #{lib} #{version} to use #{lib} functions."
+    # :nocov:
   end
 end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1,3 +1,4 @@
+require 'daru/platform.rb'
 require 'daru/maths/arithmetic/vector.rb'
 require 'daru/maths/statistics/vector.rb'
 require 'daru/plotting/gruff.rb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'vendor'
   add_filter 'spec'
+  add_filter 'lib/daru/platform'   # full covg not possible on single platform
   minimum_coverage_by_file 95
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,6 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'vendor'
   add_filter 'spec'
-  add_filter 'lib/daru/platform'   # full covg not possible on single platform
   minimum_coverage_by_file 95
 end
 


### PR DESCRIPTION
- goal: files like daru/dataframe should be funtional on their own
- daru/dataframe could not be required because it calls Daru.has_nyaplot?
- Daru.has_nyaplot? is defined in lib/daru.rb, which pulls in all of daru
  including dara/dataframe
- to avoid circular dependencies and to allow files to stand on their own, it
  is necessary to separate critical functionality from require-the-world
- move critical, common functionality like Daru.has_nyaplot? into
  daru/platform
- require daru/platform where needed, like lib/daru and daru/dataframe
- now, this works: require 'daru/dataframe'