### PR TITLE
Deprecate use of reportbuilder in DataFrame summary

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -52,7 +52,6 @@ EOF
 
   spec.add_runtime_dependency 'backports'
 
-  spec.add_development_dependency 'reportbuilder', '~> 1.4'
   spec.add_development_dependency 'spreadsheet', '~> 1.1.1'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~>10.5'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -80,14 +80,12 @@ module Daru
   create_has_library :gruff
 end
 
-[['reportbuilder', '~>1.4'], ['spreadsheet', '~>1.1.1']].each do |lib|
-  begin
-    gem lib[0], lib[1]
-    require lib[0]
-  rescue LoadError
-    STDERR.puts "\nInstall the #{lib[0]} gem version #{lib[1]} for using"\
-    " #{lib[0]} functions."
-  end
+begin
+  gem 'spreadsheet', '~>1.1.1'
+  require 'spreadsheet'
+rescue LoadError
+  STDERR.puts "\nInstall the spreadsheet gem version ~>1.1.1 for using"\
+  ' spreadsheet functions.'
 end
 
 autoload :CSV, 'csv'

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1413,19 +1413,16 @@ module Daru
       Daru::DataFrame.new(arry, clone: cln, order: order, index: @index)
     end
 
-    # Generate a summary of this DataFrame with ReportBuilder.
-    def summary(method=:to_text)
-      ReportBuilder.new(no_title: true).add(self).send(method)
-    end
-
-    def report_building(b) # :nodoc: #
-      b.section(name: @name) do |g|
-        g.text "Number of rows: #{nrows}"
-        @vectors.each do |v|
-          g.text "Element:[#{v}]"
-          g.parse_element(self[v])
-        end
+    # Generate a summary of this DataFrame based on individual vectors in the DataFrame
+    # @return [String] String containing the summary of the DataFrame
+    def summary
+      summary = "= #{name}"
+      summary << "\n  Number of rows: #{nrows}"
+      @vectors.each do |v|
+        summary << "\n  Element:[#{v}]\n"
+        summary << self[v].summary(1)
       end
+      summary
     end
 
     # Sorts a dataframe (ascending/descending) in the given pripority sequence of

--- a/lib/daru/formatters/table.rb
+++ b/lib/daru/formatters/table.rb
@@ -10,6 +10,7 @@ module Daru
         @data = data || []
         @headers = (headers || []).to_a
         @row_headers = (row_headers || []).to_a
+        @row_headers = [''] * @data.to_a.size if @row_headers.empty?
       end
 
       DEFAULT_SPACING = 10

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -879,41 +879,66 @@ module Daru
       to_html
     end
 
-    # Create a summary of the Vector using Report Builder.
-    def summary(method=:to_text)
-      ReportBuilder.new(no_title: true).add(self).send(method)
-    end
-
-    # :nocov:
-    def report_building b # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-      b.section(name: name) do |s|
-        s.text "n :#{size}"
-        s.text "n valid:#{count_values(*Daru::MISSING_VALUES)}"
-        if @type == :object
-          s.text  "factors: #{factors.to_a.join(',')}"
-          s.text  "mode: #{mode}"
-
-          s.table(name: 'Distribution') do |t|
-            frequencies.sort_by(&:to_s).each do |k,v|
-              key = @index.include?(k) ? @index[k] : k
-              t.row [key, v, ('%0.2f%%' % (v.quo(count_values(*Daru::MISSING_VALUES))*100))]
-            end
-          end
-        end
-
-        s.text "median: #{median}" if @type==:numeric || @type==:numeric
-        if @type==:numeric
-          s.text 'mean: %0.4f' % mean
-          if sd
-            s.text 'std.dev.: %0.4f' % sd
-            s.text 'std.err.: %0.4f' % se
-            s.text 'skew: %0.4f' % skew
-            s.text 'kurtosis: %0.4f' % kurtosis
-          end
-        end
+    # Create a summary of the Vector
+    # @params [Fixnum] indent_level
+    # @return [String] String containing the summary of the Vector
+    # @example
+    #   dv = Daru::Vector.new [1, 2, 3]
+    #   puts dv.summary
+    #
+    #   =
+    #     n :3
+    #     n valid:0
+    #     median: 2
+    #     mean: 2.0000
+    #     std.dev.: 1.0000
+    #     std.err.: 0.5774
+    #     skew: 0.0000
+    #     kurtosis: -2.3333
+    def summary(indent_level=0)
+      non_missing = size - count_values(*Daru::MISSING_VALUES)
+      summary = '  =' * indent_level + "= #{name}" \
+                "\n  n :#{size}" \
+                "\n  non-missing:#{non_missing}"
+      case type
+      when :object
+        summary << object_summary
+      when :numeric
+        summary << numeric_summary
       end
+      summary = summary.split("\n").join("\n" + '  ' * indent_level)
+      summary
     end
-    # :nocov:
+
+    # Displays summary for an object type Vector
+    # @return [String] String containing object vector summary
+    def object_summary
+      nval = count_values(*Daru::MISSING_VALUES)
+      summary = "\n  factors: #{factors.to_a.join(',')}" \
+                "\n  mode: #{mode}" \
+                "\n  Distribution"
+
+      data = frequencies.sort.each_with_index.map do |v, k|
+        [k, v, '%0.2f%%' % ((nval.zero? ? 1 : v.quo(nval))*100)]
+      end
+
+      summary << Daru::Formatters::Table.format(data, {headers: ['']*3, row_headers: ['']*frequencies.size})
+      summary
+    end
+
+    # Displays summary for an numeric type Vector
+    # @return [String] String containing numeric vector summary
+    def numeric_summary
+      summary = "\n  median: #{median}" +
+                "\n  mean: %0.4f" % mean
+      if sd
+        summary << "\n  std.dev.: %0.4f" % sd +
+                   "\n  std.err.: %0.4f" % se +
+                   "\n  skew: %0.4f" % skew +
+                   "\n  kurtosis: %0.4f" % kurtosis
+      end
+      summary
+    end
 
     # Over rides original inspect for pretty printing in irb
     def inspect spacing=20, threshold=15

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -888,7 +888,7 @@ module Daru
     #
     #   =
     #     n :3
-    #     n valid:0
+    #     non-missing:3
     #     median: 2
     #     mean: 2.0000
     #     std.dev.: 1.0000
@@ -915,14 +915,14 @@ module Daru
     def object_summary
       nval = count_values(*Daru::MISSING_VALUES)
       summary = "\n  factors: #{factors.to_a.join(',')}" \
-                "\n  mode: #{mode}" \
+                "\n  mode: #{mode.to_a.join(',')}" \
                 "\n  Distribution"
 
       data = frequencies.sort.each_with_index.map do |v, k|
         [k, v, '%0.2f%%' % ((nval.zero? ? 1 : v.quo(nval))*100)]
       end
 
-      summary << Daru::Formatters::Table.format(data, {headers: ['']*3, row_headers: ['']*frequencies.size})
+      summary << Daru::Formatters::Table.format(data, headers: ['']*3, row_headers: ['']*frequencies.size)
       summary
     end
 
@@ -933,8 +933,11 @@ module Daru
                 "\n  mean: %0.4f" % mean
       if sd
         summary << "\n  std.dev.: %0.4f" % sd +
-                   "\n  std.err.: %0.4f" % se +
-                   "\n  skew: %0.4f" % skew +
+                   "\n  std.err.: %0.4f" % se
+      end
+
+      if count_values(*Daru::MISSING_VALUES).zero?
+        summary << "\n  skew: %0.4f" % skew +
                    "\n  kurtosis: %0.4f" % kurtosis
       end
       summary

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -906,8 +906,7 @@ module Daru
       when :numeric
         summary << numeric_summary
       end
-      summary = summary.split("\n").join("\n" + '  ' * indent_level)
-      summary
+      summary.split("\n").join("\n" + '  ' * indent_level)
     end
 
     # Displays summary for an object type Vector
@@ -922,8 +921,7 @@ module Daru
         [k, v, '%0.2f%%' % ((nval.zero? ? 1 : v.quo(nval))*100)]
       end
 
-      summary << Daru::Formatters::Table.format(data, headers: ['']*3, row_headers: ['']*frequencies.size)
-      summary
+      summary + table(data)
     end
 
     # Displays summary for an numeric type Vector
@@ -1575,6 +1573,14 @@ module Daru
         vector_index.sort(&DEFAULT_SORTER)
       end
         .tap { |res| res.reverse! unless opts[:ascending] }
+    end
+
+    def table data
+      Formatters::Table.format(
+        data,
+        headers: ['']*3,
+        row_headers: ['']*frequencies.size
+      )
     end
   end
 end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -886,15 +886,15 @@ module Daru
     #   dv = Daru::Vector.new [1, 2, 3]
     #   puts dv.summary
     #
-    #   =
-    #     n :3
-    #     non-missing:3
-    #     median: 2
-    #     mean: 2.0000
-    #     std.dev.: 1.0000
-    #     std.err.: 0.5774
-    #     skew: 0.0000
-    #     kurtosis: -2.3333
+    #   # =
+    #   #   n :3
+    #   #   non-missing:3
+    #   #   median: 2
+    #   #   mean: 2.0000
+    #   #   std.dev.: 1.0000
+    #   #   std.err.: 0.5774
+    #   #   skew: 0.0000
+    #   #   kurtosis: -2.3333
     def summary(indent_level=0)
       non_missing = size - count_values(*Daru::MISSING_VALUES)
       summary = '  =' * indent_level + "= #{name}" \
@@ -915,13 +915,13 @@ module Daru
       nval = count_values(*Daru::MISSING_VALUES)
       summary = "\n  factors: #{factors.to_a.join(',')}" \
                 "\n  mode: #{mode.to_a.join(',')}" \
-                "\n  Distribution"
+                "\n  Distribution\n"
 
       data = frequencies.sort.each_with_index.map do |v, k|
         [k, v, '%0.2f%%' % ((nval.zero? ? 1 : v.quo(nval))*100)]
       end
 
-      summary + table(data)
+      summary + Formatters::Table.format(data)
     end
 
     # Displays summary for an numeric type Vector
@@ -1573,14 +1573,6 @@ module Daru
         vector_index.sort(&DEFAULT_SORTER)
       end
         .tap { |res| res.reverse! unless opts[:ascending] }
-    end
-
-    def table data
-      Formatters::Table.format(
-        data,
-        headers: ['']*3,
-        row_headers: ['']*frequencies.size
-      )
     end
   end
 end

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3050,9 +3050,34 @@ describe Daru::DataFrame do
   end
 
   context "#summary" do
-    it "produces a summary of data frame" do
-      expect(@data_frame.summary.match("#{@data_frame.name}")).to_not eq(nil)
-      expect(@df_mi.summary.match("#{@df_mi.name}")).to_not eq(nil)
+    subject { df.summary }
+
+    context "DataFrame" do
+      let(:df) { Daru::DataFrame.new({a: [1,2,5], b: [1,2,"string"]}, order: [:a, :b], index: [:one, :two, :three], name: 'frame') }
+      it { is_expected.to eq %Q{
+            |= frame
+            |  Number of rows: 3
+            |  Element:[a]
+            |  == a
+            |    n :3
+            |    non-missing:3
+            |    median: 2
+            |    mean: 2.6667
+            |    std.dev.: 2.0817
+            |    std.err.: 1.2019
+            |    skew: 0.2874
+            |    kurtosis: -2.3333
+            |  Element:[b]
+            |  == b
+            |    n :3
+            |    non-missing:3
+            |    factors: 1,2,string
+            |    mode: 1,2,string
+            |    Distribution                                
+            |                 1       1 100.00%
+            |                 2       1 100.00%
+            |            string       1 100.00%
+        }.unindent }
     end
   end
 

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3073,7 +3073,7 @@ describe Daru::DataFrame do
             |    non-missing:3
             |    factors: 1,2,string
             |    mode: 1,2,string
-            |    Distribution                                
+            |    Distribution
             |                 1       1 100.00%
             |                 2       1 100.00%
             |            string       1 100.00%

--- a/spec/formatters/table_formatter_spec.rb
+++ b/spec/formatters/table_formatter_spec.rb
@@ -105,4 +105,33 @@ describe Daru::Formatters::Table do
       }.unindent}
     end
   end
+
+  context 'no row and column headers' do
+    let(:headers) { nil }
+    let(:row_headers) { nil }
+    it { is_expected.to eq %Q{
+        |       1   2   3
+        |       4   5   6
+        |       7   8   9
+      }.unindent }
+  end
+
+  context 'row headers only' do
+    let(:headers) { nil }
+    it { is_expected.to eq %Q{
+        | row1    1    2    3
+        | row2    4    5    6
+        | row3    7    8    9
+      }.unindent }
+  end
+
+  context 'column headers only' do
+    let(:row_headers) { nil }
+    it { is_expected.to eq %Q{
+        |      col1 col2 col3
+        |         1    2    3
+        |         4    5    6
+        |         7    8    9
+      }.unindent }
+  end
 end

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1400,18 +1400,33 @@ describe Daru::Vector do
           context "object type" do
             let(:dv) { Daru::Vector.new([1,1,2,2,"string",nil,Float::NAN], name: 'object') }
 
-            it { is_expected.to eq %Q{
+            if RUBY_VERSION >= '2.2'
+              it { is_expected.to eq %Q{
+                  |= object
+                  |  n :7
+                  |  non-missing:5
+                  |  factors: 1,2,string
+                  |  mode: 1,2
+                  |  Distribution                                
+                  |          string       1  50.00%
+                  |             NaN       1  50.00%
+                  |               1       2 100.00%
+                  |               2       2 100.00%
+                }.unindent }
+            else
+              it { is_expected.to eq %Q{
                 |= object
                 |  n :7
                 |  non-missing:5
                 |  factors: 1,2,string
                 |  mode: 1,2
                 |  Distribution                                
-                |          string       1  50.00%
                 |             NaN       1  50.00%
-                |               1       2 100.00%
+                |          string       1  50.00%
                 |               2       2 100.00%
+                |               1       2 100.00%
               }.unindent }
+            end
           end
         end
       end

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1407,7 +1407,7 @@ describe Daru::Vector do
                   |  non-missing:5
                   |  factors: 1,2,string
                   |  mode: 1,2
-                  |  Distribution                                
+                  |  Distribution
                   |          string       1  50.00%
                   |             NaN       1  50.00%
                   |               1       2 100.00%
@@ -1420,7 +1420,7 @@ describe Daru::Vector do
                 |  non-missing:5
                 |  factors: 1,2,string
                 |  mode: 1,2
-                |  Distribution                                
+                |  Distribution
                 |             NaN       1  50.00%
                 |          string       1  50.00%
                 |               2       2 100.00%


### PR DESCRIPTION
Fixes #221 

This replaces the use of `reportbuilder` for `DataFrame` summary and uses Daru `DataFrame` and `Vector` methods in place.