### PR TITLE
where clause when data contains missing/undefined values

### DIFF
--- a/lib/daru/core/query.rb
+++ b/lib/daru/core/query.rb
@@ -39,7 +39,7 @@ module Daru
 
       class << self
         def apply_scalar_operator operator, data, other
-          BoolArray.new data.map { |d| d.respond_to?(operator) && !!d.send(operator, other) }
+          BoolArray.new data.map { |d| !!d.send(operator, other) if d.respond_to?(operator) }
         end
 
         def apply_vector_operator operator, vector, other

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -352,7 +352,10 @@ module Daru
         if other.is_a?(Daru::Vector)
           mod.apply_vector_operator operator, self, other
         else
-          mod.apply_scalar_operator operator, @data,other
+          data_dup = @data.dup
+          missing_undefined_indexes = nil_positions + nan_positions
+          missing_undefined_indexes.each { |i| data_dup.delete_at(i) }
+          mod.apply_scalar_operator operator, data_dup, other
         end
       end
       alias_method operator, method if operator != :== && operator != :!=

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -352,10 +352,14 @@ module Daru
         if other.is_a?(Daru::Vector)
           mod.apply_vector_operator operator, self, other
         else
-          data_dup = @data.dup
           missing_undefined_indexes = nil_positions + nan_positions
-          missing_undefined_indexes.each { |i| data_dup.delete_at(i) }
-          mod.apply_scalar_operator operator, data_dup, other
+          if operator != :== && operator != :!= && missing_undefined_indexes.size
+            data_dup = @data.dup
+            missing_undefined_indexes.each { |i| data_dup.delete_at(i) }
+            mod.apply_scalar_operator operator, data_dup, other
+          else
+            mod.apply_scalar_operator operator, data, other
+          end
         end
       end
       alias_method operator, method if operator != :== && operator != :!=

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -352,14 +352,7 @@ module Daru
         if other.is_a?(Daru::Vector)
           mod.apply_vector_operator operator, self, other
         else
-          missing_undefined_indexes = nil_positions + nan_positions
-          if operator != :== && operator != :!= && missing_undefined_indexes.size
-            data_dup = @data.dup
-            missing_undefined_indexes.each { |i| data_dup.delete_at(i) }
-            mod.apply_scalar_operator operator, data_dup, other
-          else
-            mod.apply_scalar_operator operator, data, other
-          end
+          mod.apply_scalar_operator operator, @data, other
         end
       end
       alias_method operator, method if operator != :== && operator != :!=

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1390,17 +1390,17 @@ describe Daru::Vector do
 
   context '#is_values' do
     let(:dv) { Daru::Vector.new [10, 11, 10, nil, nil] }
-    
+
     context 'single value' do
       subject { dv.is_values 10 }
       it { is_expected.to be_a Daru::Vector }
       its(:to_a) { is_expected.to eq [true, false, true, false, false] }
     end
-    
+
     context 'multiple values' do
       subject { dv.is_values 10, nil }
       it { is_expected.to be_a Daru::Vector }
-      its(:to_a) { is_expected.to eq [true, false, true, true, true] }      
+      its(:to_a) { is_expected.to eq [true, false, true, true, true] }
     end
   end
 
@@ -1996,13 +1996,12 @@ describe Daru::Vector do
   end
 
   context '#where clause when Nan, nil data value is present' do
-    before do
-        @v = Daru::Vector.new([1,2,3,Float::NAN, nil])
-    end
+    let(:v) { Daru::Vector.new([1,2,3,Float::NAN, nil]) }
+
     it 'missing/undefined data in Vector/DataFrame' do
-      expect(@v.where(@v.lt(4))).to eq(Daru::Vector.new([1,2,3]))
-      expect(@v.where(@v.lt(3))).to eq(Daru::Vector.new([1,2]))
-      expect(@v.where(@v.lt(2))).to eq(Daru::Vector.new([1]))
+      expect(v.where(v.lt(4))).to eq(Daru::Vector.new([1,2,3]))
+      expect(v.where(v.lt(3))).to eq(Daru::Vector.new([1,2]))
+      expect(v.where(v.lt(2))).to eq(Daru::Vector.new([1]))
     end
   end
 

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1995,4 +1995,15 @@ describe Daru::Vector do
     end
   end
 
+  context '#where clause when Nan, nil data value is present' do
+    before do
+        @v = Daru::Vector.new([1,2,3,Float::NAN, nil])
+    end
+    it 'missing/undefined data in Vector/DataFrame' do
+      expect { @v.where(v.lt(4)) }.to eq(Daru::Vector.new([1,2,3]))
+      expect { @v.where(v.lt(3)) }.to eq(Daru::Vector.new([1,2]))
+      expect { @v.where(v.lt(2)) }.to eq(Daru::Vector.new([1]))
+    end
+  end
+
 end if mri?

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -2000,9 +2000,9 @@ describe Daru::Vector do
         @v = Daru::Vector.new([1,2,3,Float::NAN, nil])
     end
     it 'missing/undefined data in Vector/DataFrame' do
-      expect { @v.where(v.lt(4)) }.to eq(Daru::Vector.new([1,2,3]))
-      expect { @v.where(v.lt(3)) }.to eq(Daru::Vector.new([1,2]))
-      expect { @v.where(v.lt(2)) }.to eq(Daru::Vector.new([1]))
+      expect(@v.where(@v.lt(4))).to eq(Daru::Vector.new([1,2,3]))
+      expect(@v.where(@v.lt(3))).to eq(Daru::Vector.new([1,2]))
+      expect(@v.where(@v.lt(2))).to eq(Daru::Vector.new([1]))
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/SciRuby/daru/issues/246

```
irb(main):001:0> v= Daru::Vector.new([1,2,3,Float::NAN, nil])
=> #<Daru::Vector(5)>
   0   1
   1   2
   2   3
   3 NaN
   4 nil
irb(main):002:0> v.where(v.lt(4))
=> #<Daru::Vector(3)>
   0   1
   1   2
   2   3
irb(main):003:0> v.where(v.lt(3))
=> #<Daru::Vector(2)>
   0   1
   1   2
irb(main):004:0> v.where(v.lt(2))
=> #<Daru::Vector(1)>
   0   1
irb(main):005:0> v.where(v.lt(1))
=> #<Daru::Vector(0)>
```