### PR TITLE
 defined `is_values` in Index

### DIFF
--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -187,6 +187,12 @@ module Daru
       @relation_hash.key? index
     end
 
+    # To check whether index value is any element of list `indexes`.
+    #
+    # @param indexes [Array] the list of indexes.
+    # @return [Object] the Vector having true/false values. `true` at position `i`
+    # if i'th index value is present in `indexes` . If i'th index value is not
+    # present in `indexes` array then `false` at position `i` of the Vector.
     def isin indexes
       bool_array = @relation_hash.keys.map { |r| indexes.include?(r) }
       Daru::Vector.new(bool_array)

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -187,13 +187,23 @@ module Daru
       @relation_hash.key? index
     end
 
-    # To check whether index value is any element of list `indexes`.
-    #
-    # @param indexes [Array] the list of indexes.
-    # @return [Object] the Vector having true/false values. `true` at position `i`
-    # if i'th index value is present in `indexes` . If i'th index value is not
-    # present in `indexes` array then `false` at position `i` of the Vector.
-    def isin indexes
+    # @note Do not use it to check for Float::NAN as
+    #   Float::NAN == Float::NAN is false
+    # Return vector of booleans with value at ith position is either
+    # true or false depending upon whether index value at position i is equal to
+    # any of the values passed in the argument or not
+    # @param [Array] *indexes values to equate with
+    # @return [Daru::Vector] vector of boolean values
+    # @example
+    #   dv = Daru::Index.new [1, 2, 3, :one, 'one']
+    #   dv.is_values 1, 'one'
+    #   # => #<Daru::Vector(5)>
+    #   #     0  true
+    #   #     1  false
+    #   #     2  false
+    #   #     3  false
+    #   #     4  true
+    def is_values *indexes
       bool_array = @relation_hash.keys.map { |r| indexes.include?(r) }
       Daru::Vector.new(bool_array)
     end

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -203,7 +203,7 @@ module Daru
     #   #     2  false
     #   #     3  false
     #   #     4  true
-    def is_values *indexes
+    def is_values(*indexes) # rubocop:disable Style/PredicateName
       bool_array = @relation_hash.keys.map { |r| indexes.include?(r) }
       Daru::Vector.new(bool_array)
     end

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -187,6 +187,11 @@ module Daru
       @relation_hash.key? index
     end
 
+    def isin indexes
+      bool_array = @relation_hash.keys.map { |r| indexes.include?(r) }
+      Daru::Vector.new(bool_array)
+    end
+
     def empty?
       @relation_hash.empty?
     end

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -295,4 +295,18 @@ describe Daru::Index do
       it { expect(idx.select {|w| w[0] == 'g' }).to eq(['guitar']) }
     end
   end
+
+  context "#isin" do
+    let(:di) { Daru::Index.new [:one, 'one', 1, 2, 'two'] }
+    let(:list1) {['one', 1]}
+    let(:list2) {['two', 2]}
+    let(:list3) {[2, :one]}
+    let(:list4) {[]}
+    let(:klass) { Daru::Vector }
+
+    it { expect(di.isin(list1)).to eq(klass.new([false, true, true, false, false])) }
+    it { expect(di.isin(list2)).to eq(klass.new([false, false, false, true, true])) }
+    it { expect(di.isin(list3)).to eq(klass.new([true, false, false, true, false])) }
+    it { expect(di.isin(list4)).to eq(klass.new([false, false, false, false, false])) }
+  end
 end

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -296,17 +296,46 @@ describe Daru::Index do
     end
   end
 
-  context "#isin" do
-    let(:di) { Daru::Index.new [:one, 'one', 1, 2, 'two'] }
-    let(:list1) {['one', 1]}
-    let(:list2) {['two', 2]}
-    let(:list3) {[2, :one]}
-    let(:list4) {[]}
+  context "#is_values" do
     let(:klass) { Daru::Vector }
+    let(:idx) { described_class.new [:one, 'one', 1, 2, 'two', nil, [1, 2]] }
 
-    it { expect(di.isin(list1)).to eq(klass.new([false, true, true, false, false])) }
-    it { expect(di.isin(list2)).to eq(klass.new([false, false, false, true, true])) }
-    it { expect(di.isin(list3)).to eq(klass.new([true, false, false, true, false])) }
-    it { expect(di.isin(list4)).to eq(klass.new([false, false, false, false, false])) }
+    context "no arguments" do
+      it { expect(idx.is_values).to eq klass.new([false, false, false, false, false, false, false]) }
+    end
+
+    context "single arguments" do
+      it { expect(idx.is_values 'one').to eq klass.new([false, true, false, false, false, false, false]) }
+    end
+
+    context "multiple arguments" do
+      context "symbol and number as argument" do
+        subject { idx.is_values 2, :one }
+        it { is_expected.to be_a Daru::Vector }
+        its(:size) { is_expected.to eq 7 }
+        it { is_expected.to eq klass.new([true, false, false, true, false, false, false]) }
+      end
+
+      context "string and number as argument" do
+        subject { idx.is_values('one', 1)}
+        it { is_expected.to be_a Daru::Vector }
+        its(:size) { is_expected.to eq 7 }
+        it { is_expected.to eq klass.new([false, true, true, false, false, false, false]) }
+      end
+
+      context "nil is present in arguments" do
+        subject { idx.is_values('two', nil)}
+        it { is_expected.to be_a Daru::Vector }
+        its(:size) { is_expected.to eq 7 }
+        it { is_expected.to eq klass.new([false, false, false, false, true, true, false]) }
+      end
+
+      context "subarray is present in arguments" do
+        subject { idx.is_values([1, 2])}
+        it { is_expected.to be_a Daru::Vector }
+        its(:size) { is_expected.to eq 7 }
+        it { is_expected.to eq klass.new([false, false, false, false, false, false, true]) }
+      end
+    end
   end
 end

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -301,40 +301,46 @@ describe Daru::Index do
     let(:idx) { described_class.new [:one, 'one', 1, 2, 'two', nil, [1, 2]] }
 
     context "no arguments" do
-      it { expect(idx.is_values).to eq klass.new([false, false, false, false, false, false, false]) }
+      let(:answer) { [false, false, false, false, false, false, false] }
+      it { expect(idx.is_values).to eq klass.new(answer) }
     end
 
     context "single arguments" do
-      it { expect(idx.is_values 'one').to eq klass.new([false, true, false, false, false, false, false]) }
+      let(:answer) { [false, true, false, false, false, false, false] }
+      it { expect(idx.is_values 'one').to eq klass.new(answer) }
     end
 
     context "multiple arguments" do
       context "symbol and number as argument" do
         subject { idx.is_values 2, :one }
+        let(:answer) { [true, false, false, true, false, false, false] }
         it { is_expected.to be_a Daru::Vector }
         its(:size) { is_expected.to eq 7 }
-        it { is_expected.to eq klass.new([true, false, false, true, false, false, false]) }
+        it { is_expected.to eq klass.new(answer) }
       end
 
       context "string and number as argument" do
         subject { idx.is_values('one', 1)}
+        let(:answer) { [false, true, true, false, false, false, false] }
         it { is_expected.to be_a Daru::Vector }
         its(:size) { is_expected.to eq 7 }
-        it { is_expected.to eq klass.new([false, true, true, false, false, false, false]) }
+        it { is_expected.to eq klass.new(answer) }
       end
 
       context "nil is present in arguments" do
         subject { idx.is_values('two', nil)}
+        let(:answer) { [false, false, false, false, true, true, false] }
         it { is_expected.to be_a Daru::Vector }
         its(:size) { is_expected.to eq 7 }
-        it { is_expected.to eq klass.new([false, false, false, false, true, true, false]) }
+        it { is_expected.to eq klass.new(answer) }
       end
 
       context "subarray is present in arguments" do
         subject { idx.is_values([1, 2])}
+        let(:answer) { [false, false, false, false, false, false, true] }
         it { is_expected.to be_a Daru::Vector }
         its(:size) { is_expected.to eq 7 }
-        it { is_expected.to eq klass.new([false, false, false, false, false, false, true]) }
+        it { is_expected.to eq klass.new(answer) }
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/SciRuby/daru/issues/211
E.g 
```
irb(main):004:0> d = Daru::Index.new [:one, 'one', 1, 2, :two]
=> #<Daru::Index(5): {one, one, 1, 2, two}>
irb(main):005:0> d.isin(['one', :one, 2])
=> #<Daru::Vector(5)>
     0  true
     1  true
     2 false
     3  true
     4 false
```