### PR TITLE
defining sort for Index and sort_by_index for vector

### DIFF
--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -1,5 +1,5 @@
 module Daru
-  class Index
+  class Index # rubocop:disable Metrics/ClassLength
     include Enumerable
     # It so happens that over riding the .new method in a super class also
     # tampers with the default .new method for class that inherit from the
@@ -220,6 +220,31 @@ module Daru
     def reorder(new_order)
       from = to_a
       self.class.new(new_order.map { |i| from[i] })
+    end
+
+    # Sorts a `Index`, according to its values. Defaults to ascending order sorting.
+    #
+    # == Options:
+    #
+    # ascending::
+    #   This can be `true` or `false`. False, to get descending order.
+    #
+    # == Returns:
+    # sorted `Index` according to its values.
+    #
+    # == Usage
+    #
+    #   di = Daru::Index.new [100, 99, 101, 1, 2]
+    #   # Say you want to sort descending order
+    #   di.sort(ascending: false)
+    def sort opts={}
+      opts = {ascending: true}.merge(opts)
+      if opts[:ascending]
+        new_index, = @relation_hash.sort.transpose
+      else
+        new_index, = @relation_hash.sort.reverse.transpose
+      end
+      self.class.new(new_index)
     end
 
     private

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -222,21 +222,20 @@ module Daru
       self.class.new(new_order.map { |i| from[i] })
     end
 
-    # Sorts a `Index`, according to its values. Defaults to ascending order sorting.
+    # Sorts a `Index`, according to its values. Defaults to ascending order
+    # sorting.
     #
-    # == Options:
+    # @param [Hash] opts the options for sort method.
+    # @option opts [Boolean] :ascending False, to get descending order.
     #
-    # ascending::
-    #   This can be `true` or `false`. False, to get descending order.
+    # @return [Index] sorted `Index` according to its values.
     #
-    # == Returns:
-    # sorted `Index` according to its values.
-    #
-    # == Usage
-    #
+    # @example
     #   di = Daru::Index.new [100, 99, 101, 1, 2]
-    #   # Say you want to sort descending order
-    #   di.sort(ascending: false)
+    #   # Say you want to sort in descending order
+    #   di.sort(ascending: false) #=> Daru::Index.new [101, 100, 99, 2, 1]
+    #   # Say you want to sort in ascending order
+    #   di.sort #=> Daru::Index.new [1, 2, 99, 100, 101]
     def sort opts={}
       opts = {ascending: true}.merge(opts)
       if opts[:ascending]
@@ -244,6 +243,7 @@ module Daru
       else
         new_index, = @relation_hash.sort.reverse.transpose
       end
+
       self.class.new(new_index)
     end
 

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -623,8 +623,7 @@ module Daru
     #   #=> Daru::Vector.new [11, 12, 13], index: [23, 22, 21]
     def sort_by_index opts={}
       opts = {ascending: true}.merge(opts)
-      new_arrangement = resort_index(@index.each_with_index, opts)
-      _, new_order = new_arrangement.transpose
+      _, new_order = resort_index(@index.each_with_index, opts).transpose
 
       reorder new_order
     end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -603,6 +603,31 @@ module Daru
       Daru::Vector.new(vector, index: index, name: @name, dtype: @dtype)
     end
 
+    # Sorts the vector according to it's`Index` values. Defaults to ascending
+    # order sorting.
+    #
+    # == Options
+    #
+    # ascending::
+    #   This can be `true` or `false`. False, if false, will sort `index` in
+    #   descending order. Defaults to true.
+    #
+    # == Returns:
+    #   new sorted `Vector` according to the index values.
+    #
+    # == Usage
+    #
+    #   dv = Daru::Vector.new [11, 12, 13], index: [23, 22, 21]
+    #   # Say you want to sort index in descending order
+    #   di.sort_by_index(ascending: false)
+    def sort_by_index opts={}
+      opts = {ascending: true}.merge(opts)
+      new_arrangement = resort_index(@index.each_with_index, opts)
+      _, new_order = new_arrangement.transpose
+
+      reorder new_order
+    end
+
     DEFAULT_SORTER = lambda { |(lv, li), (rv, ri)|
       case
       when lv.nil? && rv.nil?

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -606,20 +606,21 @@ module Daru
     # Sorts the vector according to it's`Index` values. Defaults to ascending
     # order sorting.
     #
-    # == Options
+    # @param [Hash] opts the options for sort_by_index method.
+    # @option opts [Boolean] :ascending false, will sort `index` in
+    #  descending order.
     #
-    # ascending::
-    #   This can be `true` or `false`. False, if false, will sort `index` in
-    #   descending order. Defaults to true.
+    # @return [Vector] new sorted `Vector` according to the index values.
     #
-    # == Returns:
-    #   new sorted `Vector` according to the index values.
+    # @example
     #
-    # == Usage
-    #
-    #   dv = Daru::Vector.new [11, 12, 13], index: [23, 22, 21]
+    #   dv = Daru::Vector.new [11, 13, 12], index: [23, 21, 22]
+    #   # Say you want to sort index in ascending order
+    #   dv.sort_by_index(ascending: true)
+    #   #=> Daru::Vector.new [13, 12, 11], index: [21, 22, 23]
     #   # Say you want to sort index in descending order
-    #   di.sort_by_index(ascending: false)
+    #   dv.sort_by_index(ascending: false)
+    #   #=> Daru::Vector.new [11, 12, 13], index: [23, 22, 21]
     def sort_by_index opts={}
       opts = {ascending: true}.merge(opts)
       new_arrangement = resort_index(@index.each_with_index, opts)

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -71,16 +71,21 @@ describe Daru::Index do
   end
 
   context '#sort' do
-    let(:string_index) { Daru::Index.new ['speaker', 'mic', 'guitar', 'amp'] }
-    let(:num_index) { Daru::Index.new [100, 99, 101, 1, 2] }
-    it 'when index values are string' do
-      expect(string_index.sort()).to eq Daru::Index.new ['amp', 'guitar', 'mic', 'speaker']
-      expect(string_index.sort(ascending: false)).to eq string_index
+    let(:asc) { index.sort }
+    let(:desc) { index.sort(ascending: false) }
+
+    context 'string index' do
+      let(:index) { Daru::Index.new ['mic', 'amp', 'guitar', 'speaker'] }
+      specify { expect(asc).to eq Daru::Index.new ['amp', 'guitar', 'mic',
+       'speaker'] }
+      specify { expect(desc).to eq Daru::Index.new ['speaker', 'mic', 'guitar',
+       'amp'] }
     end
 
-    it 'when index values are numbers' do
-      expect(num_index.sort()).to eq Daru::Index.new [1, 2, 99, 100, 101]
-      expect(num_index.sort(ascending: false)).to eq Daru::Index.new [101, 100, 99, 2, 1]
+    context 'number index' do
+      let(:index) { Daru::Index.new [100, 99, 101, 1, 2]  }
+      specify { expect(asc).to eq Daru::Index.new [1, 2, 99, 100, 101] }
+      specify { expect(desc).to eq Daru::Index.new [101, 100, 99, 2, 1] }
     end
   end
 

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -70,6 +70,20 @@ describe Daru::Index do
     end
   end
 
+  context '#sort' do
+    let(:string_index) { Daru::Index.new ['speaker', 'mic', 'guitar', 'amp'] }
+    let(:num_index) { Daru::Index.new [100, 99, 101, 1, 2] }
+    it 'when index values are string' do
+      expect(string_index.sort()).to eq Daru::Index.new ['amp', 'guitar', 'mic', 'speaker']
+      expect(string_index.sort(ascending: false)).to eq string_index
+    end
+
+    it 'when index values are numbers' do
+      expect(num_index.sort()).to eq Daru::Index.new [1, 2, 99, 100, 101]
+      expect(num_index.sort(ascending: false)).to eq Daru::Index.new [101, 100, 99, 2, 1]
+    end
+  end
+
   context "#size" do
     it "correctly returns the size of the index" do
       idx = Daru::Index.new ['speaker', 'mic', 'guitar', 'amp']

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1390,17 +1390,17 @@ describe Daru::Vector do
 
   context '#is_values' do
     let(:dv) { Daru::Vector.new [10, 11, 10, nil, nil] }
-    
+
     context 'single value' do
       subject { dv.is_values 10 }
       it { is_expected.to be_a Daru::Vector }
       its(:to_a) { is_expected.to eq [true, false, true, false, false] }
     end
-    
+
     context 'multiple values' do
       subject { dv.is_values 10, nil }
       it { is_expected.to be_a Daru::Vector }
-      its(:to_a) { is_expected.to eq [true, false, true, true, true] }      
+      its(:to_a) { is_expected.to eq [true, false, true, true, true] }
     end
   end
 
@@ -1963,6 +1963,21 @@ describe Daru::Vector do
         # FIXME: inconsistency between IndexError here and NoMethodError on getting - zverok
         expect { vector.d = 5 }.to raise_error IndexError
       end
+    end
+  end
+
+  context "#sort_by_index" do
+    let(:num_vector) { Daru::Vector.new [11, 12, 13], index: [23, 22, 21] }
+    let(:other_types) { Daru::Vector.new [11, Float::NAN, nil], index: [23, 22, 21] }
+
+    it "by default sort in ascending order" do
+      expect(num_vector.sort_by_index().to_a).to eq([13, 12, 11])
+      expect(other_types.sort_by_index().to_a).to eq([nil, Float::NAN, 11])
+    end
+
+    it "sorts the vector in descending order" do
+      expect(num_vector.sort_by_index(ascending: false)).to eq(num_vector)
+      expect(other_types.sort_by_index(ascending: false).to_a).to eq([11, Float::NAN, nil])
     end
   end
 

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1967,17 +1967,20 @@ describe Daru::Vector do
   end
 
   context "#sort_by_index" do
-    let(:num_vector) { Daru::Vector.new [11, 12, 13], index: [23, 22, 21] }
-    let(:other_types) { Daru::Vector.new [11, Float::NAN, nil], index: [23, 22, 21] }
+    let(:asc) { vector.sort_by_index }
+    let(:desc) { vector.sort_by_index(ascending: false) }
 
-    it "by default sort in ascending order" do
-      expect(num_vector.sort_by_index().to_a).to eq([13, 12, 11])
-      expect(other_types.sort_by_index().to_a).to eq([nil, Float::NAN, 11])
+    context 'numeric vector' do
+      let(:vector) { Daru::Vector.new [11, 13, 12], index: [23, 21, 22] }
+      specify { expect(asc.to_a).to eq [13, 12, 11] }
+      specify { expect(desc.to_a).to eq [11, 12, 13] }
     end
 
-    it "sorts the vector in descending order" do
-      expect(num_vector.sort_by_index(ascending: false)).to eq(num_vector)
-      expect(other_types.sort_by_index(ascending: false).to_a).to eq([11, Float::NAN, nil])
+    context 'mix variable type index' do
+      let(:vector) { Daru::Vector.new [11, Float::NAN, nil],
+                              index: [21, 23, 22] }
+      specify { expect(asc.to_a).to eq [11, nil, Float::NAN] }
+      specify { expect(desc.to_a).to eq [Float::NAN, nil, 11] }
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/SciRuby/daru/issues/159

```
irb(main):007:0> dv = Daru::Vector.new [11, Float::NAN, nil], index: [23, 22, 21]
=> #<Daru::Vector(3)>
  23  11
  22 NaN
  21 nil
irb(main):008:0> dv.sort_by_index()
=> #<Daru::Vector(3)>
  21 nil
  22 NaN
  23  11
irb(main):009:0> dv = Daru::Vector.new [11, 12, 13], index: [23, 22, 21]
=> #<Daru::Vector(3)>
  23  11
  22  12
  21  13
irb(main):010:0> dv.sort_by_index()
=> #<Daru::Vector(3)>
  21  13
  22  12
  23  11
irb(main):011:0> dv.sort_by_index(ascending: false)
=> #<Daru::Vector(3)>
  23  11
  22  12
  21  13
```