### PR TITLE
Adds default order for Daru::DataFrame (issue #130)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@ AllCops:
   Include:
     - 'lib/**/*'
   Exclude:
+    - 'daru.gemspec'
+    - 'Rakefile'
+    - 'Gemfile'
+    - 'Guardfile'
     - '**/*.erb'
     - 'spec/*'
     - 'spec/**/*'

--- a/lib/daru/accessors/gsl_wrapper.rb
+++ b/lib/daru/accessors/gsl_wrapper.rb
@@ -65,7 +65,7 @@ if Daru.has_gsl?
           ::GSL::Vector.alloc(@data.to_a - [Float::NAN])
         end
 
-        [:mean, :min, :max, :prod, :sum].each do |method|
+        %i[mean min max prod sum].each do |method|
           define_method(method) do
             compact.send(method.to_sym) rescue nil
           end

--- a/lib/daru/category.rb
+++ b/lib/daru/category.rb
@@ -461,7 +461,7 @@ module Daru
       @coding_scheme = scheme
     end
 
-    CODING_SCHEMES = [:dummy, :deviation, :helmert, :simple].freeze
+    CODING_SCHEMES = %i[dummy deviation helmert simple].freeze
 
     # Contrast code the vector acording to the coding scheme set.
     # @note To set the coding scheme use #coding_scheme=

--- a/lib/daru/core/query.rb
+++ b/lib/daru/core/query.rb
@@ -9,13 +9,13 @@ module Daru
         end
 
         def & other
-          BoolArray.new @barry.zip(other.barry).map { |b, o| b && o }
+          BoolArray.new(@barry.zip(other.barry).map { |b, o| b && o })
         end
 
         alias :and :&
 
         def | other
-          BoolArray.new @barry.zip(other.barry).map { |b, o| b || o }
+          BoolArray.new(@barry.zip(other.barry).map { |b, o| b || o })
         end
 
         alias :or :|
@@ -39,11 +39,11 @@ module Daru
 
       class << self
         def apply_scalar_operator operator, data, other
-          BoolArray.new data.map { |d| !!d.send(operator, other) if d.respond_to?(operator) }
+          BoolArray.new(data.map { |d| !!d.send(operator, other) if d.respond_to?(operator) })
         end
 
         def apply_vector_operator operator, vector, other
-          BoolArray.new vector.zip(other).map { |d, o| !!d.send(operator, o) }
+          BoolArray.new(vector.zip(other).map { |d, o| !!d.send(operator, o) })
         end
 
         def df_where data_frame, bool_array

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -250,10 +250,10 @@ module Daru
     #   # =>
     #   # #<Daru::DataFrame: bat_man (4x2)>
     #   #             0          1
-    #   #  0          6          1
-    #   #  1          7          2
-    #   #  2          8          3
-    #   #  3          9          4
+    #   #  0          1          6
+    #   #  1          2          7
+    #   #  2          3          8
+    #   #  3          4          9
 
     def initialize source, opts={} # rubocop:disable Metrics/MethodLength
       vectors, index = opts[:order], opts[:index] # FIXME: just keyword arges after Ruby 2.1

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -929,7 +929,7 @@ module Daru
 
     # creates a new vector with the data of a given field which the block returns true
     def filter_vector vec, &block
-      Daru::Vector.new each_row.select(&block).map { |row| row[vec] }
+      Daru::Vector.new(each_row.select(&block).map { |row| row[vec] })
     end
 
     # Iterates over each row and retains it in a new DataFrame if the block returns
@@ -1047,7 +1047,7 @@ module Daru
     alias :vector_missing_values :missing_values_rows
 
     def has_missing_data?
-      !!@data.any? { |vec| vec.include_values?(*Daru::MISSING_VALUES) }
+      @data.any? { |vec| vec.include_values?(*Daru::MISSING_VALUES) }
     end
     alias :flawed? :has_missing_data?
     deprecate :has_missing_data?, :include_values?, 2016, 10
@@ -1393,7 +1393,7 @@ module Daru
     #   df.rename_vectors :a => :alpha, :c => :gamma
     #   df.vectors.to_a #=> [:alpha, :b, :gamma]
     def rename_vectors name_map
-      existing_targets = name_map.select { |k,v| k != v }.values & vectors.to_a
+      existing_targets = name_map.reject { |k,v| k == v }.values & vectors.to_a
       delete_vectors(*existing_targets)
 
       new_names = vectors.to_a.map { |v| name_map[v] ? name_map[v] : v }
@@ -2066,7 +2066,7 @@ module Daru
       end
     end
 
-    AXES = [:row, :vector].freeze
+    AXES = %i[row vector].freeze
 
     def extract_axis names, default=:vector
       if AXES.include?(names.last)

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -244,6 +244,17 @@ module Daru
     #   #  b          7          2
     #   #  c          8          3
     #   #  d          9          4
+    #
+    #   df = Daru::DataFrame.new([[1,2,3,4],[6,7,8,9]], name: :bat_man)
+    #
+    #   # =>
+    #   # #<Daru::DataFrame: bat_man (4x2)>
+    #   #             0          1
+    #   #  0          6          1
+    #   #  1          7          2
+    #   #  2          8          3
+    #   #  3          9          4
+
     def initialize source, opts={} # rubocop:disable Metrics/MethodLength
       vectors, index = opts[:order], opts[:index] # FIXME: just keyword arges after Ruby 2.1
       @data = []
@@ -2278,8 +2289,10 @@ module Daru
 
       case source.first
       when Array
+        vectors = (0..source.size-1).to_a if vectors.nil?
         initialize_from_array_of_arrays source, vectors, index, opts
       when Vector
+        vectors = (0..source.size-1).to_a if vectors.nil?
         initialize_from_array_of_vectors source, vectors, index, opts
       when Hash
         initialize_from_array_of_hashes source, vectors, index, opts

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2289,10 +2289,10 @@ module Daru
 
       case source.first
       when Array
-        vectors = (0..source.size-1).to_a if vectors.nil?
+        vectors ||= (0..source.size-1).to_a
         initialize_from_array_of_arrays source, vectors, index, opts
       when Vector
-        vectors = (0..source.size-1).to_a if vectors.nil?
+        vectors ||= (0..source.size-1).to_a
         initialize_from_array_of_vectors source, vectors, index, opts
       when Hash
         initialize_from_array_of_hashes source, vectors, index, opts

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -490,7 +490,7 @@ module Daru
     #   @return [Array<Integer>] Array containing minutes of each index.
     # @!method sec
     #   @return [Array<Integer>] Array containing seconds of each index.
-    [:year, :month, :day, :hour, :min, :sec].each do |meth|
+    %i[year month day hour min sec].each do |meth|
       define_method(meth) do
         each_with_object([]) do |d, arr|
           arr << d.send(meth)

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -120,7 +120,7 @@ module Daru
         Daru::Index.new indexes
       else
         # Assume 'indexes' contain positions not indexes
-        Daru::Index.new indexes.map { |k| key k }
+        Daru::Index.new(indexes.map { |k| key k })
       end
     end
 
@@ -290,11 +290,11 @@ module Daru
 
     def by_multi_key *key
       if include? key[0]
-        Daru::Index.new key.map { |k| k }
+        Daru::Index.new(key.map { |k| k })
       else
         # Assume the user is specifing values for index not keys
         # Return index object having keys corresponding to values provided
-        Daru::Index.new key.map { |k| key k }
+        Daru::Index.new(key.map { |k| key k })
       end
     end
 

--- a/lib/daru/io/io.rb
+++ b/lib/daru/io/io.rb
@@ -187,7 +187,7 @@ module Daru
 
       private
 
-      DARU_OPT_KEYS = [:clone, :order, :index, :name].freeze
+      DARU_OPT_KEYS = %i[clone order index name].freeze
 
       def from_csv_prepare_opts opts
         opts[:col_sep]           ||= ','

--- a/lib/daru/maths/statistics/dataframe.rb
+++ b/lib/daru/maths/statistics/dataframe.rb
@@ -22,7 +22,7 @@ module Daru
         #   Calculate the minimum value of each numeric vector
         # @!method product
         #   Compute the product of each numeric vector
-        [:mean, :variance_sample, :range, :median, :mode, :std, :sum, :count, :min, :product].each do |meth|
+        %i[mean variance_sample range median mode std sum count min product].each do |meth|
           define_method(meth) do
             compute_stats meth
           end
@@ -70,9 +70,9 @@ module Daru
         # @!method rolling_variance
         #   Calculate moving variance
         #   @param [Integer] n (10) Loopback length. Default to 10.
-        [
-          :cumsum,:standardize,:acf,:ema,:rolling_mean,:rolling_median,:rolling_max,
-          :rolling_min,:rolling_count,:rolling_std,:rolling_variance, :rolling_sum
+        %i[
+          cumsum standardize acf ema rolling_mean rolling_median rolling_max
+          rolling_min rolling_count rolling_std rolling_variance rolling_sum
         ].each do |meth|
           define_method(meth) do |*args|
             apply_method_to_numerics meth, *args
@@ -88,7 +88,7 @@ module Daru
         # be applied to numeric vectors. Default is [:count, :mean, :std, :max,
         # :min]. Methods will be applied in the specified order.
         def describe methods=nil
-          methods ||= [:count, :mean, :std, :min, :max]
+          methods ||= %i[count mean std min max]
 
           description_hash = {}
           numeric_vectors.each do |vec|

--- a/lib/daru/maths/statistics/vector.rb
+++ b/lib/daru/maths/statistics/vector.rb
@@ -41,7 +41,7 @@ module Daru
         # be applied to vectors. Default is [:count, :mean, :std, :max,
         # :min]. Methods will be applied in the specified order.
         def describe methods=nil
-          methods ||= [:count, :mean, :std, :min, :max]
+          methods ||= %i[count mean std min max]
           description = methods.map { |m| send(m) }
           Daru::Vector.new(description, index: methods, name: :statistics)
         end
@@ -571,7 +571,7 @@ module Daru
         # @!method rolling_variance
         #   Calculate rolling variance
         #   @param [Integer] n (10) Loopback length
-        [:count, :mean, :median, :max, :min, :sum, :std, :variance].each do |meth|
+        %i[count mean median max min sum std variance].each do |meth|
           define_method("rolling_#{meth}".to_sym) do |n=10|
             rolling(meth, n)
           end

--- a/lib/daru/plotting/nyaplot/dataframe.rb
+++ b/lib/daru/plotting/nyaplot/dataframe.rb
@@ -38,7 +38,7 @@ module Daru
 
           diagram =
             case
-            when !([:scatter, :bar, :line, :histogram] & types).empty?
+            when !(%i[scatter bar line histogram] & types).empty?
               plot_regular_diagrams plot, opts
             when types.include?(:box)
               plot_box_diagram plot
@@ -102,7 +102,7 @@ module Daru
           end
         end
 
-        SHAPES = %w(circle triangle-up diamond square triangle-down cross).freeze
+        SHAPES = %w[circle triangle-up diamond square triangle-down cross].freeze
         def get_shape type
           validate_type type, :scatter
           SHAPES.cycle

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -555,7 +555,7 @@ module Daru
     # Get index of element
     def index_of element
       case dtype
-      when :array then @index.key @data.index { |x| x.eql? element }
+      when :array then @index.key(@data.index { |x| x.eql? element })
       else @index.key @data.index(element)
       end
     end
@@ -669,7 +669,7 @@ module Daru
     def delete_if
       return to_enum(:delete_if) unless block_given?
 
-      keep_e, keep_i = each_with_index.select { |n, _i| !yield(n) }.transpose
+      keep_e, keep_i = each_with_index.reject { |n, _i| yield(n) }.transpose
 
       @data = cast_vector_to @dtype, keep_e
       @index = Daru::Index.new(keep_i)

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -329,6 +329,14 @@ describe Daru::DataFrame do
         expect(df[:a])         .to eq(Daru::Vector.new([1,2,3,4,5]))
       end
 
+      it "allows creation of dataframe with a default order" do
+        arr_of_arrs_df    = Daru::DataFrame.new([[1,2,3], [4,5,6], [7,8,9]])
+        arr_of_vectors_df = Daru::DataFrame.new([Daru::Vector.new([1,2,3]), Daru::Vector.new([4,5,6]), Daru::Vector.new([7,8,9])])
+
+        expect(arr_of_arrs_df.vectors.to_a).to eq([0,1,2])
+        expect(arr_of_vectors_df.vectors.to_a).to eq([0,1,2])
+      end
+
       it "raises error for incomplete DataFrame index" do
         expect {
           df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],


### PR DESCRIPTION
Rspec test added, has been written in the older format to main consistency. This will be easier to change while re-writing all tests to modern specifications file-wise, rather than modernizing specs for individual functions. RDoc documentation has also been added.

Tackles issue #130 