### PR TITLE
df.group_by returns dataframe with multi index

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2018,18 +2018,17 @@ module Daru
     # returns array of row tuples at given index(s)
     def access_row_tuples_by_indexs *indexes
       positions = @index.pos(*indexes)
-      if positions.is_a? Numeric
-        return populate_row_for(positions)
-      else
-        res = []
-        new_rows = @data.map { |vec| vec[*indexes] }
-        indexes.each do |index|
-          tuples = []
-          new_rows.map {|row| tuples += [row[index]]}
-          res << tuples
-        end
-        return res
+
+      return populate_row_for(positions) if positions.is_a? Numeric
+
+      res = []
+      new_rows = @data.map { |vec| vec[*indexes] }
+      indexes.each do |index|
+        tuples = []
+        new_rows.map { |row| tuples += [row[index]] }
+        res << tuples
       end
+      res
     end
 
     private

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1244,7 +1244,7 @@ module Daru
 
       vectors = [@vectors.first] if vectors.empty?
 
-      Daru::Core::GroupBy.new(self, vectors)
+      Daru::Core::GroupBy.new(self, vectors).context_new
     end
 
     def reindex_vectors new_vectors
@@ -2012,6 +2012,23 @@ module Daru
         where(cat_dv.eq cat)
           .rename(cat)
           .delete_vector cat_name
+      end
+    end
+
+    # returns array of row tuples at given index(s)
+    def access_row_tuples_by_indexs *indexes
+      positions = @index.pos(*indexes)
+      if positions.is_a? Numeric
+        return populate_row_for(positions)
+      else
+        res = []
+        new_rows = @data.map { |vec| vec[*indexes] }
+        indexes.each do |index|
+          tuples = []
+          new_rows.map {|row| tuples += [row[index]]}
+          res << tuples
+        end
+        return res
       end
     end
 

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1244,7 +1244,7 @@ module Daru
 
       vectors = [@vectors.first] if vectors.empty?
 
-      Daru::Core::GroupBy.new(self, vectors).context_new
+      Daru::Core::GroupBy.new(self, vectors)
     end
 
     def reindex_vectors new_vectors

--- a/spec/core/group_by_spec.rb
+++ b/spec/core/group_by_spec.rb
@@ -30,12 +30,6 @@ describe Daru::Core::GroupBy do
       ['foo', 'two'  , 3]
     ])
 
-    @df2 = Daru::DataFrame.new(
-      employee: %w[John Jane Mark John Jane Mark],
-      month: %w[June June June July July July],
-      salary: [1000, 500, 700, 1200, 600, 600]
-    )
-    @employee_grp = @df2.group_by(:employee)
   end
 
   context 'with nil values' do
@@ -53,6 +47,19 @@ describe Daru::Core::GroupBy do
   end
 
   context "#initialize" do
+    let(:df_emp) { Daru::DataFrame.new(
+      employee: %w[John Jane Mark John Jane Mark],
+      month: %w[June June June July July July],
+      salary: [1000, 500, 700, 1200, 600, 600]
+    ) }
+    let(:employee_grp) { df_emp.group_by(:employee).df }
+    let(:mi_single) { Daru::MultiIndex.from_tuples([
+        ['Jane', 1], ['Jane', 4], ['John', 0],
+        ['John', 3], ['Mark', 2], ['Mark', 5]
+        ]
+      )}
+    let(:vec_single) { Daru::Index.new(['month', 'salary']) }
+
     it "groups by a single tuple" do
       expect(@sl_group.groups).to eq({
         ['bar'] => [1,3,5],
@@ -61,18 +68,10 @@ describe Daru::Core::GroupBy do
     end
 
     it "returns dataframe with multi-index" do
-      let(:mi) { Daru::MultiIndex.from_tuples([
-        ['Jane', 1], ['Jane', 4], ['John', 0],
-        ['John', 3], ['Mark', 2], ['Mark', 6]
-        ]
-      )}
-      let(:vec) { Daru::Index.new(
-        ['month', 'salary']) }
-      expect(@employee_grp.index).to eq(mi)
-      expect(@employee_grp).to eq(Daru::DataFrame.new({
+      expect(employee_grp).to eq(Daru::DataFrame.new({
         month: ["June", "July", "June", "July", "June", "July"],
         salary: [500, 600, 1000, 1200, 700, 600]
-        }, index: mi))
+        }, index: mi_single))
     end
 
     it "groups by a double layer hierarchy" do

--- a/spec/core/group_by_spec.rb
+++ b/spec/core/group_by_spec.rb
@@ -58,7 +58,22 @@ describe Daru::Core::GroupBy do
         ['John', 3], ['Mark', 2], ['Mark', 5]
         ]
       )}
-    let(:vec_single) { Daru::Index.new(['month', 'salary']) }
+
+    let(:emp_month_grp) { df_emp.group_by([:employee, :month]).df }
+    let(:mi_double) { Daru::MultiIndex.from_tuples([
+        ['Jane', 'July', 4], ['Jane', 'June', 1], ['John', 'July', 3],
+        ['John', 'June', 0], ['Mark', 'July', 5], ['Mark', 'June', 2]
+        ]
+      )}
+
+    let(:emp_month_salary_grp) {
+      df_emp.group_by([:employee, :month, :salary]).df }
+    let(:mi_triple) { Daru::MultiIndex.from_tuples([
+        ['Jane', 'July', 600, 4], ['Jane', 'June', 500, 1],
+        ['John', 'July', 1200, 3], ['John', 'June', 1000, 0],
+        ['Mark', 'July', 600, 5], ['Mark', 'June', 700, 2]
+        ]
+      )}
 
     it "groups by a single tuple" do
       expect(@sl_group.groups).to eq({
@@ -67,11 +82,22 @@ describe Daru::Core::GroupBy do
       })
     end
 
-    it "returns dataframe with multi-index" do
+    it "returns dataframe with MultiIndex, groups by single layer hierarchy" do
       expect(employee_grp).to eq(Daru::DataFrame.new({
         month: ["June", "July", "June", "July", "June", "July"],
         salary: [500, 600, 1000, 1200, 700, 600]
         }, index: mi_single))
+    end
+
+    it "returns dataframe with MultiIndex, groups by double layer hierarchy" do
+      expect(emp_month_grp).to eq(Daru::DataFrame.new({
+        salary: [600, 500, 1200, 1000, 600, 700]
+        }, index: mi_double))
+    end
+
+    it "returns dataframe with MultiIndex, groups by triple layer hierarchy" do
+      expect(emp_month_salary_grp).to eq(Daru::DataFrame.new({
+        }, index: mi_triple))
     end
 
     it "groups by a double layer hierarchy" do

--- a/spec/core/group_by_spec.rb
+++ b/spec/core/group_by_spec.rb
@@ -29,6 +29,13 @@ describe Daru::Core::GroupBy do
       ['foo', 'three', 8],
       ['foo', 'two'  , 3]
     ])
+
+    @df2 = Daru::DataFrame.new(
+      employee: %w[John Jane Mark John Jane Mark],
+      month: %w[June June June July July July],
+      salary: [1000, 500, 700, 1200, 600, 600]
+    )
+    @employee_grp = @df2.group_by(:employee)
   end
 
   context 'with nil values' do
@@ -51,6 +58,21 @@ describe Daru::Core::GroupBy do
         ['bar'] => [1,3,5],
         ['foo'] => [0,2,4,6,7]
       })
+    end
+
+    it "returns dataframe with multi-index" do
+      let(:mi) { Daru::MultiIndex.from_tuples([
+        ['Jane', 1], ['Jane', 4], ['John', 0],
+        ['John', 3], ['Mark', 2], ['Mark', 6]
+        ]
+      )}
+      let(:vec) { Daru::Index.new(
+        ['month', 'salary']) }
+      expect(@employee_grp.index).to eq(mi)
+      expect(@employee_grp).to eq(Daru::DataFrame.new({
+        month: ["June", "July", "June", "July", "June", "July"],
+        salary: [500, 600, 1000, 1200, 700, 600]
+        }, index: mi))
     end
 
     it "groups by a double layer hierarchy" do


### PR DESCRIPTION
Fixes #152 Part 1 

Example : 

```
irb(main):001:0> df = Daru::DataFrame.new(
irb(main):002:1*   {employee: %w[John Jane Mark John Jane Mark],
irb(main):003:2*   month: %w[June June June July July July],
irb(main):004:2*   salary: [1000, 500, 700, 1200, 600, 600]}
irb(main):005:1> )
=> #<Daru::DataFrame(6x3)>
          employee    month   salary
        0     John     June     1000
        1     Jane     June      500
        2     Mark     June      700
        3     John     July     1200
        4     Jane     July      600
        5     Mark     July      600
irb(main):006:0> df.group_by(:employee)
=> #<Daru::DataFrame(6x2)>
                month salary
   Jane      1   June    500
             4   July    600
   John      0   June   1000
             3   July   1200
   Mark      2   June    700
             5   July    600
irb(main):007:0> 

irb(main):007:0> d2 = Daru::Index.new [100, 99, 101, 1, 2,3]
=> #<Daru::Index(6): {100, 99, 101, 1, 2, 3}>
irb(main):008:0> df = Daru::DataFrame.new(
irb(main):009:1*   {employee: %w[John John Jane Jane Mark Mark],
irb(main):010:2*   month: %w[June June June July July July],
irb(main):011:2*   salary: [1000, 500, 700, 1200, 600, 600]}, index: d2
irb(main):012:1> )
=> #<Daru::DataFrame(6x3)>
          employee    month   salary
      100     John     June     1000
       99     John     June      500
      101     Jane     June      700
        1     Jane     July     1200
        2     Mark     July      600
        3     Mark     July      600
irb(main):013:0> df.group_by(:employee)
=> #<Daru::DataFrame(6x2)>
                month salary
   Jane    101   June    700
             1   July   1200
   John    100   June   1000
            99   June    500
   Mark      2   July    600
             3   July    600

```