### PR TITLE
Define Daru::Index#[] to take only index value as argument 

### DIFF
--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -196,15 +196,8 @@ module Daru
         transpose = elements.transpose
         rows      = indexes.each.map { |idx| transpose[idx] }
 
-        new_index =
-          begin
-            @context.index[indexes]
-          rescue IndexError
-            indexes
-          end
-
         Daru::DataFrame.rows(
-          rows, index: new_index, order: @context.vectors
+          rows, index: indexes, order: @context.vectors
         )
       end
 

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -504,7 +504,7 @@ module Daru
     def dup vectors_to_dup=nil
       vectors_to_dup = @vectors.to_a unless vectors_to_dup
 
-      src = vectors_to_dup.map { |vec| @data[@vectors[vec]].dup }
+      src = vectors_to_dup.map { |vec| @data[@vectors.pos(vec)].dup }
       new_order = Daru::Index.new(vectors_to_dup)
 
       Daru::DataFrame.new src, order: new_order, index: @index.dup, name: @name, clone: true
@@ -2132,7 +2132,7 @@ module Daru
 
     def access_vector *names
       if names.first.is_a?(Range)
-        dup(@vectors[names.first])
+        dup(@vectors.subset(names.first))
       elsif @vectors.is_a?(MultiIndex)
         access_vector_multi_index(*names)
       else
@@ -2155,7 +2155,7 @@ module Daru
     def access_vector_single_index *names
       if names.count < 2
         begin
-          pos = @vectors[names.first]
+          pos = @vectors.is_a?(Daru::DateTimeIndex) ? @vectors[names.first] : @vectors.pos(names.first)
         rescue IndexError
           raise IndexError, "Specified vector #{names.first} does not exist"
         end
@@ -2165,7 +2165,7 @@ module Daru
         names = pos
       end
 
-      new_vectors = names.map { |name| [name, @data[@vectors[name]]] }.to_h
+      new_vectors = names.map { |name| [name, @data[@vectors.pos(name)]] }.to_h
 
       order = names.is_a?(Array) ? Daru::Index.new(names) : names
       Daru::DataFrame.new(new_vectors, order: order,

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -185,25 +185,25 @@ describe Daru::Index do
     end
 
     it "works with ranges" do
-      expect(@id[:two..:five]).to eq(Daru::Index.new([:two, :three, :four, :five]))
+      expect(@id[:two..:five]).to eq([1, 2, 3, 4])
 
-      expect(@mixed_id['a'..'c']).to eq(Daru::Index.new(['a','b','c']))
+      expect(@mixed_id['a'..'c']).to eq([0, 1, 2])
 
-      # If both start and end are numbers then refer to numerical indexes
-      expect(@mixed_id[0..2]).to eq(Daru::Index.new(['a','b','c']))
+      # returns nil if first index is invalid
+      expect(@mixed_id.slice('d', 5)).to be_nil
 
-      # If atleast one is a number then refer to actual indexing
-      expect(@mixed_id.slice('b',8)).to eq(Daru::Index.new(['b','c',:d,:a,8]))
+      # returns positions till the end if first index is present
+      expect(@mixed_id.slice('c', 6)).to eq([2, 3, 4, 5, 6, 7])
     end
 
     it "returns multiple keys if specified multiple indices" do
-      expect(@id[0,1,3,4]).to eq(Daru::Index.new([:one, :two, :four, :five]))
-      expect(@mixed_id[0,5,3,2]).to eq(Daru::Index.new(['a', 8, :d, 'c']))
+      expect(@id[:one, :two, :four, :five]).to eq([0, 1, 3, 4])
+      expect(@mixed_id[0,5,3,2]).to eq([nil, 7, 6, nil])
     end
 
-    it "returns correct index position for non-numeric index" do
+    it "returns nil for invalid indexes" do
       expect(@id[:four]).to eq(3)
-      expect(@id[3]).to eq(3)
+      expect(@id[3]).to be_nil
     end
 
     it "returns correct index position for mixed index" do


### PR DESCRIPTION
Daru::Index#[] now only takes index values and returns positions only. If index is not found it returns nil
```
2.3.0 :001 > index = Daru::Index.new [:one, :two, :three, :four] => #<Daru::Index(4): {one, two, three, four}> 
2.3.0 :002 > index[:one..:three] 
 => [0, 1, 2] 
2.3.0 :003 > index[:five..:six]
 => nil 
2.3.0 :004 > index[:one, 0]
 => [0, nil] 
2.3.0 :005 > index[:two]
 => 1 
2.3.0 :006 > index[2]
 => nil 

```