### PR TITLE
Fix empty DateTimeIndex

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,11 @@ Style/EmptyCaseCondition:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '[]'
+    '%w': '[]'
+
 # Neither of prefered styles are good enough :(
 Style/BlockDelimiters:
   Enabled: false

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -529,7 +529,7 @@ module Daru
       slice first, last
     end
 
-    def slice_between_dates first, last # rubocop:disable Metrics/AbcSize
+    def slice_between_dates first, last # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
       # about that ^ disable: I'm waiting for cleaner understanding
       # of offsets logic. Reference: https://github.com/v0dro/daru/commit/7e1c34aec9516a9ba33037b4a1daaaaf1de0726a#diff-a95ef410a8e1f4ea3cc48d231bb880faR250
       start    = @data.bsearch { |d| d[0] >= first }

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -405,7 +405,7 @@ module Daru
         @data
       else
         @data.sort_by(&:last)
-      end.transpose.first
+      end.transpose.first || []
     end
 
     # Size of index.
@@ -419,6 +419,7 @@ module Daru
 
     def inspect
       meta = [@periods, @frequency ? "frequency=#{@frequency}" : nil].compact.join(', ')
+      return "#<#{self.class}(#{meta})>" if @data.empty?
       "#<#{self.class}(#{meta}) " \
          "#{@data.first[0]}...#{@data.last[0]}>"
     end
@@ -542,7 +543,7 @@ module Daru
         st = @data.index(start)
         en = after_en ? @data.index(after_en) - 1 : Helper.last_date(@data)[1]
         return start[1] if st == en
-        DateTimeIndex.new(@data[st..en].transpose[0])
+        DateTimeIndex.new(@data[st..en].transpose[0] || []) # empty slice guard
       end
     end
 

--- a/spec/date_time/index_spec.rb
+++ b/spec/date_time/index_spec.rb
@@ -202,6 +202,11 @@ describe DateTimeIndex do
         "#<Daru::DateTimeIndex(4) 2014-07-01T00:00:00+00:00...2014-07-04T00:00:00+00:00>"
       }
     end
+
+    context 'empty index' do
+      let(:index){ DateTimeIndex.new([]) }
+      it { is_expected.to eq "#<Daru::DateTimeIndex(0)>" }
+    end
   end
 
   context "#frequency" do
@@ -242,6 +247,14 @@ describe DateTimeIndex do
         DateTime.new(2015,7),DateTime.new(2013,7)])
       expect(index['2014']).to eq(DateTimeIndex.new([
         DateTime.new(2014,5),DateTime.new(2014,7)]))
+    end
+
+    it 'does not fail on absent data' do
+      index = DateTimeIndex.new([
+        DateTime.new(2014,5),DateTime.new(2018,6),DateTime.new(2014,7),DateTime.new(2016,7),
+        DateTime.new(2013,7)])
+      p DateTimeIndex.new([])
+      expect(index['2015']).to eq(DateTimeIndex.new([]))
     end
 
     it "accepts only year for frequency data" do
@@ -504,6 +517,11 @@ describe DateTimeIndex do
         start: DateTime.new(2012,2,1), :end => DateTime.new(2012,2,4))
       expect(index.to_a).to eq([
         DateTime.new(2012,2,1),DateTime.new(2012,2,2),DateTime.new(2012,2,3),DateTime.new(2012,2,4)])
+    end
+
+    context 'empty index' do
+      subject(:index) { DateTimeIndex.new([]) }
+      its(:to_a) { is_expected.to eq [] }
     end
   end
 


### PR DESCRIPTION
#338 

Fixes `#inspect`, `#to_a` for empty indexes and `#[]` with no results.