### PR TITLE
make Daru::DataFrame#covariance faster

### DIFF
--- a/lib/daru/maths/statistics/dataframe.rb
+++ b/lib/daru/maths/statistics/dataframe.rb
@@ -141,11 +141,7 @@ module Daru
 
           mat_rows = vectors.collect do |row|
             vectors.collect do |col|
-              if row == col
-                self[row].variance
-              else
-                cache[[col,row]]
-              end
+              row == col ? self[row].variance : cache[[col,row]]
             end
           end
 

--- a/lib/daru/maths/statistics/dataframe.rb
+++ b/lib/daru/maths/statistics/dataframe.rb
@@ -133,7 +133,9 @@ module Daru
         # Calculate sample variance-covariance between the numeric vectors.
         def covariance
           cache = Hash.new do |h, (col, row)|
-            h[[col, row]] = vector_cov(self[row],self[col])
+            value = vector_cov(self[row],self[col])
+            h[[col, row]] = value
+            h[[row, col]] = value
           end
           vectors = numeric_vectors
 


### PR DESCRIPTION
Roughly it becomes 2 times faster.

I confirmed that result of `#coveriance` doesn't change.

Should I write some benchmarks or tests?