### PR TITLE
Actualize for the new Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
   TargetRubyVersion: 2.0
 
 # Preferred codebase style ---------------------------------------------
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   AllowForAlignment: true
 
 Style/FormatString:
@@ -25,16 +25,16 @@ Style/FormatString:
 Style/AndOr:
   EnforcedStyle: conditionals
 
-Style/SpaceAroundEqualsInParameterDefault:
+Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 
-Style/SpaceInsideBlockBraces:
+Layout/SpaceInsideBlockBraces:
   EnforcedStyle: space
 
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 Style/EmptyElse:
@@ -61,16 +61,20 @@ Style/SingleLineBlockParams:
 Style/PerlBackrefs:
   Enabled: false
 
-Style/SpaceAfterComma:
+Layout/SpaceAfterComma:
   Enabled: false
 
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: false
 
 Style/EmptyCaseCondition:
   Enabled: false
 
 Style/MultilineBlockChain:
+  Enabled: false
+
+# See https://github.com/bbatsov/rubocop/issues/4429
+Style/YodaCondition:
   Enabled: false
 
 Style/PercentLiteralDelimiters:

--- a/daru.gemspec
+++ b/daru.gemspec
@@ -69,7 +69,7 @@ EOF
   spec.add_development_dependency 'dbi'
   spec.add_development_dependency 'activerecord', '~> 4.0'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'rubocop', '>= 0.40.0'
+  spec.add_development_dependency 'rubocop', '~> 0.49.0'
   spec.add_development_dependency 'ruby-prof'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'gruff'

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -726,7 +726,7 @@ module Daru
     # * +axis+ - The axis to map over. Can be :vector (or :column) or :row.
     # Default to :vector.
     def map! axis=:vector, &block
-      if axis == :vector || axis == :column
+      if %i[vector column].include?(axis)
         map_vectors!(&block)
       elsif axis == :row
         map_rows!(&block)
@@ -1166,7 +1166,7 @@ module Daru
     #     row[:a] < 3 and row[:b] == 'b'
     #   end #=> true
     def any? axis=:vector, &block
-      if axis == :vector || axis == :column
+      if %i[vector column].include?(axis)
         @data.any?(&block)
       elsif axis == :row
         each_row do |row|
@@ -1188,7 +1188,7 @@ module Daru
     #     row[:a] < 10
     #   end #=> true
     def all? axis=:vector, &block
-      if axis == :vector || axis == :column
+      if %i[vector column].include?(axis)
         @data.all?(&block)
       elsif axis == :row
         each_row.all?(&block)
@@ -2101,7 +2101,7 @@ module Daru
     end
 
     def dispatch_to_axis(axis, method, *args, &block)
-      if axis == :vector || axis == :column
+      if %i[vector column].include?(axis)
         send("#{method}_vector", *args, &block)
       elsif axis == :row
         send("#{method}_row", *args, &block)
@@ -2111,7 +2111,7 @@ module Daru
     end
 
     def dispatch_to_axis_pl(axis, method, *args, &block)
-      if axis == :vector || axis == :column
+      if %i[vector column].include?(axis)
         send("#{method}_vectors", *args, &block)
       elsif axis == :row
         send("#{method}_rows", *args, &block)

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -501,8 +501,7 @@ module Daru
     # * +:dtype+ - :array for Ruby Array. :nmatrix for NMatrix.
     def cast opts={}
       dt = opts[:dtype]
-      raise ArgumentError, "Unsupported dtype #{opts[:dtype]}" unless
-        dt == :array || dt == :nmatrix || dt == :gsl
+      raise ArgumentError, "Unsupported dtype #{opts[:dtype]}" unless %i[array nmatrix gsl].include?(dt)
 
       @data = cast_vector_to dt unless @dtype == dt
     end


### PR DESCRIPTION
Rubocop 0.49.0 added several new cops, which had led to several new offences.

This PR also fixes Rubocop version in `daru.gemspec`. Turns out that new versions are frequent, and small 1-2 lines PR of innocent contributors become severely broken suddenly. I believe now it is wiser to just update the version from time to time, and fix new offences simultaneously.