### PR TITLE
Fix head/tail calls on DataFrames with DateTime indexes and Vector_at splat calls (#341 & #331)

### DIFF
--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -226,7 +226,7 @@ module Daru
       to_a.each(&block)
     end
 
-    attr_reader :frequency, :offset, :periods
+    attr_reader :frequency, :offset, :periods, :keys
 
     # Create a DateTimeIndex with or without a frequency in data. The constructor
     # should be used for creating DateTimeIndex by directly passing in DateTime

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -253,6 +253,7 @@ module Daru
     #     DateTime.new(2012,4,11), DateTime.new(2012,4,12)], freq: :infer)
     #   #=>#<DateTimeIndex:84198340 offset=D periods=8 data=[2012-04-05T00:00:00+00:00...2012-04-12T00:00:00+00:00]>
     def initialize data, opts={freq: nil}
+      super data
       Helper.possibly_convert_to_date_time data
 
       @offset =

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -1581,6 +1581,13 @@ describe Daru::DataFrame do
     it 'has synonym' do
       expect(@data_frame.first(2)).to eq(@data_frame.head(2))
     end
+
+    it 'works on DateTime indexes' do
+      idx = Daru::DateTimeIndex.new(['2017-01-01', '2017-02-01', '2017-03-01'])
+      df = Daru::DataFrame.new({col1: ['a', 'b', 'c']}, index: idx)
+      first = Daru::DataFrame.new({col1: ['a']}, index: Daru::DateTimeIndex.new(['2017-01-01']))
+      expect(df.head(1)).to eq(first)
+    end
   end
 
   context "#last" do

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -411,6 +411,7 @@ describe Daru::Vector do
 
           context "Splat .at on DateTime index" do
             subject { dv_dt.at(*[1,2]) }
+
             it { is_expected.to be_a Daru::Vector }
             its(:size) { is_expected.to eq 2 }
             its(:to_a) { is_expected.to eq ['b', 'c'] }

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -358,6 +358,9 @@ describe Daru::Vector do
           let (:idx) { Daru::Index.new [1, 0, :c] }
           let (:dv) { Daru::Vector.new ['a', 'b', 'c'], index: idx }
 
+          let (:idx_dt) { Daru::DateTimeIndex.new(['2017-01-01', '2017-02-01', '2017-03-01']) }
+          let (:dv_dt) { Daru::Vector.new(['a', 'b', 'c'], index: idx_dt) }
+
           context "single position" do
             it { expect(dv.at 1).to eq 'b' }
           end
@@ -404,6 +407,14 @@ describe Daru::Vector do
             its(:size) { is_expected.to eq 1 }
             its(:to_a) { is_expected.to eq ['a'] }
             its(:'index.to_a') { is_expected.to eq [1] }
+          end
+
+          context "Splat .at on DateTime index" do
+            subject { dv_dt.at(*[1,2]) }
+            it { is_expected.to be_a Daru::Vector }
+            its(:size) { is_expected.to eq 2 }
+            its(:to_a) { is_expected.to eq ['b', 'c'] }
+            its(:'index.to_a') { is_expected.to eq ['2017-02-01', '2017-03-01'] }
           end
         end
 


### PR DESCRIPTION
Fixes issues https://github.com/SciRuby/daru/issues/341 and https://github.com/SciRuby/daru/issues/331 with reference to https://github.com/SciRuby/daru/pull/347 this is just adding the failing spec.