### PR TITLE
Fix Vector initialization when dtype is nmatrix, vector has nils and no nm_type is given (#153)

### DIFF
--- a/lib/daru/accessors/nmatrix_wrapper.rb
+++ b/lib/daru/accessors/nmatrix_wrapper.rb
@@ -25,7 +25,7 @@ if Daru.has_nmatrix?
         attr_reader :size, :data, :nm_dtype
 
         def initialize vector, context, nm_dtype=:int32
-          # To avoid arrays with nils throwing TypeError for :int32 default nm_dtype
+          # To avoid arrays with nils throwing TypeError for nil nm_dtype
           nm_dtype = :object if nm_dtype.nil? && vector.any?(&:nil?)
           @size = vector.size
           @data = NMatrix.new [@size*2], vector.to_a, dtype: nm_dtype

--- a/lib/daru/accessors/nmatrix_wrapper.rb
+++ b/lib/daru/accessors/nmatrix_wrapper.rb
@@ -25,6 +25,8 @@ if Daru.has_nmatrix?
         attr_reader :size, :data, :nm_dtype
 
         def initialize vector, context, nm_dtype=:int32
+          # To avoid arrays with nils throwing TypeError for :int32 default nm_dtype
+          nm_dtype = :object if nm_dtype.nil? && vector.any?(&:nil?)
           @size = vector.size
           @data = NMatrix.new [@size*2], vector.to_a, dtype: nm_dtype
           @context = context

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1481,7 +1481,7 @@ module Daru
 
     # Note: To maintain sanity, this _MUST_ be the _ONLY_ place in daru where the
     # @dtype variable is set and the underlying data type of vector changed.
-    def cast_vector_to dtype, source=nil, nm_dtype=nil
+    def cast_vector_to dtype, source=nil, nm_dtype=nil # rubocop:disable Style/CyclomaticComplexity
       source = @data.to_a if source.nil?
 
       new_vector =

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1481,22 +1481,19 @@ module Daru
 
     # Note: To maintain sanity, this _MUST_ be the _ONLY_ place in daru where the
     # @dtype variable is set and the underlying data type of vector changed.
-    def cast_vector_to dtype, source=nil, nm_dtype=nil # rubocop:disable Style/CyclomaticComplexity
+    def cast_vector_to dtype, source=nil, nm_dtype=nil
       source = @data.to_a if source.nil?
 
       new_vector =
         case dtype
         when :array   then Daru::Accessors::ArrayWrapper.new(source, self)
-        when :nmatrix then
-          # To avoid arrays with nils throwing TypeError for :int32 default nm_dtype
-          nm_dtype = :object if nm_dtype.nil? && source.any?(&:nil?)
-          Daru::Accessors::NMatrixWrapper.new(source, self, nm_dtype)
+        when :nmatrix then Daru::Accessors::NMatrixWrapper.new(source, self, nm_dtype)
         when :gsl then Daru::Accessors::GSLWrapper.new(source, self)
         when :mdarray then raise NotImplementedError, 'MDArray not yet supported.'
         else raise ArgumentError, "Unknown dtype #{dtype}"
         end
 
-      @dtype = dtype || :array
+      @dtype = dtype
       new_vector
     end
 

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1487,7 +1487,10 @@ module Daru
       new_vector =
         case dtype
         when :array   then Daru::Accessors::ArrayWrapper.new(source, self)
-        when :nmatrix then Daru::Accessors::NMatrixWrapper.new(source, self, nm_dtype)
+        when :nmatrix then
+          # To avoid arrays with nils throwing TypeError for :int32 default nm_dtype
+          nm_dtype = :object if nm_dtype.nil? && source.any?(&:nil?)
+          Daru::Accessors::NMatrixWrapper.new(source, self, nm_dtype)
         when :gsl then Daru::Accessors::GSLWrapper.new(source, self)
         when :mdarray then raise NotImplementedError, 'MDArray not yet supported.'
         else raise ArgumentError, "Unknown dtype #{dtype}"

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -84,6 +84,11 @@ describe Daru::Vector do
           expect(dv.index.to_a).to eq(['a', 'b', :r, 0])
         end
 
+        it "initializes array with nils with dtype NMatrix" do
+          dv = Daru::Vector.new [2, nil], dtype: :nmatrix
+          expect(dv.to_a).to eq([2, nil])
+          expect(dv.index.to_a).to eq([0, 1])
+        end
       end
 
       context "#reorder!" do


### PR DESCRIPTION
Fixes https://github.com/SciRuby/daru/issues/153

Cyclomatic Complexity rubocop disabled for the `cast_vector_to` method as it seems necessary with that many possible case statement branches and the method is actually all that complex.