### PR TITLE
Better Vector/DataFrame to_s methods (#142)

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1880,7 +1880,7 @@ module Daru
     end
 
     def to_s
-      to_html
+      "#<#{self.class}#{': ' + @name if @name}(#{nrows}x#{ncols})>"
     end
 
     # Method for updating the metadata (i.e. missing value positions) of the

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -916,7 +916,7 @@ module Daru
     end
 
     def to_s
-      to_html
+      "#<#{self.class}#{': ' + @name if @name}(#{size})#{':category' if category?}>"
     end
 
     # Create a summary of the Vector
@@ -985,7 +985,7 @@ module Daru
     def inspect spacing=20, threshold=15
       row_headers = index.is_a?(MultiIndex) ? index.sparse_tuples : index.to_a
 
-      "#<#{self.class}(#{size})#{':cataegory' if category?}>\n" +
+      "#<#{self.class}(#{size})#{':category' if category?}>\n" +
         Formatters::Table.format(
           to_a.lazy.map { |v| [v] },
           headers: @name && [@name],

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3832,6 +3832,10 @@ describe Daru::DataFrame do
   end
 
   context '#to_s' do
+    it 'produces a class, size description' do
+      expect(@data_frame.to_s).to eq "#<Daru::DataFrame(5x3)>"
+    end
+
     it 'produces a class, name, size description' do
       @data_frame.name = "Test"
       expect(@data_frame.to_s).to eq "#<Daru::DataFrame: Test(5x3)>"

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3832,8 +3832,9 @@ describe Daru::DataFrame do
   end
 
   context '#to_s' do
-    it 'produces something, despite of how reasonable you think it is' do
-      expect(@data_frame.to_s).to eq @data_frame.to_html
+    it 'produces a class, name, size description' do
+      @data_frame.name = "Test"
+      expect(@data_frame.to_s).to eq "#<Daru::DataFrame: Test(5x3)>"
     end
   end
 

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -998,7 +998,7 @@ describe Daru::Vector do
         its(:to_json) { is_expected.to eq(vector.to_h.to_json) }
       end
 
-      context '#to_s' do
+      context "#to_s" do
         subject(:vector) do
           Daru::Vector.new ["a", "b"], name: "Test", index: [1, 2]
         end

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -998,6 +998,14 @@ describe Daru::Vector do
         its(:to_json) { is_expected.to eq(vector.to_h.to_json) }
       end
 
+      context '#to_s' do
+        subject(:vector) do
+          Daru::Vector.new ["a", "b"], name: "Test", index: [1, 2]
+        end
+
+        its(:to_s) { is_expected.to eq "#<Daru::Vector: Test(2)>"}
+      end
+
       context "#uniq" do
         before do
           @v = Daru::Vector.new [1, 2, 2, 2.0, 3, 3.0], index:[:a, :b, :c, :d, :e, :f]

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -999,11 +999,18 @@ describe Daru::Vector do
       end
 
       context "#to_s" do
-        subject(:vector) do
-          Daru::Vector.new ["a", "b"], name: "Test", index: [1, 2]
+        before do
+          @v = Daru::Vector.new ["a", "b"], index: [1, 2]
         end
 
-        its(:to_s) { is_expected.to eq "#<Daru::Vector: Test(2)>"}
+        it 'produces a class, size description' do
+          expect(@v.to_s).to eq("#<Daru::Vector(2)>")
+        end
+
+        it 'produces a class, name, size description' do
+          @v.name = "Test"
+          expect(@v.to_s).to eq("#<Daru::Vector: Test(2)>")
+        end
       end
 
       context "#uniq" do


### PR DESCRIPTION
https://github.com/SciRuby/daru/issues/142

Produces `.to_s` results like:

```
 => "#<Daru::Vector: ExampleName(2)>"
 => "#<Daru::DataFrame: ExampleName(3x1)>"
```