### PR TITLE
Allow inserting or updating DataFrame vectors with single values #351

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2319,14 +2319,13 @@ module Daru
             v[idx] = vector.index.include?(idx) ? vector[idx] : nil
           end
         }
-      else
-        # FIXME: No spec checks this case... And SizeError is not a thing - zverok, 2016-05-08
+      elsif vector.is_a?(Array) || vector.is_a?(Range)
         if @size != vector.size
-          raise SizeError,
-            "Specified vector of length #{vector.size} cannot be inserted in DataFrame of size #{@size}"
+          raise "Specified vector of length #{vector.size} cannot be inserted in DataFrame of size #{@size}"
         end
-
         Daru::Vector.new(vector, name: coerce_name(name), index: @index)
+      else
+        Daru::Vector.new(Array(vector) * @size, name: coerce_name(name), index: @index)
       end
     end
 

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2262,7 +2262,7 @@ module Daru
       if @index.empty?
         insert_vector_in_empty name, vector
       else
-        vec = prepare_vector_for_insert name, vector
+        vec = prepare_for_insert name, vector
 
         assign_or_add_vector name, vec
       end
@@ -2309,22 +2309,25 @@ module Daru
       @data.map! { |v| v.empty? ? v.reindex(@index) : v }
     end
 
-    def prepare_vector_for_insert name, vector
-      case vector
+    def prepare_for_insert name, arg
+      case arg
       when Daru::Vector
-        # so that index-by-index assignment is avoided when possible.
-        return vector.dup if vector.index == @index
-
-        Daru::Vector.new([], name: coerce_name(name), index: @index).tap { |v|
-          @index.each do |idx|
-            v[idx] = vector.index.include?(idx) ? vector[idx] : nil
-          end
-        }
+        prepare_vector_for_insert name, arg
       when Array, Range
-        prepare_enum_for_insert name, vector
+        prepare_enum_for_insert name, arg
       else
-        prepare_value_for_insert name, vector
+        prepare_value_for_insert name, arg
       end
+    end
+
+    def prepare_vector_for_insert name, vector
+      # so that index-by-index assignment is avoided when possible.
+      return vector.dup if vector.index == @index
+      Daru::Vector.new([], name: coerce_name(name), index: @index).tap { |v|
+        @index.each do |idx|
+          v[idx] = vector.index.include?(idx) ? vector[idx] : nil
+        end
+      }
     end
 
     def prepare_enum_for_insert name, enum

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -524,6 +524,18 @@ describe Daru::DataFrame do
           index: [:one, :two, :three, :four, :five]))
       end
 
+      it "assigns new vector with default length if given just a value" do
+        @df[:d] = 1.0
+        expect(@df[:d]).to eq(Daru::Vector.new([1.0, 1.0, 1.0, 1.0, 1.0],
+        index: [:one, :two, :three, :four, :five], name: :d))
+      end
+
+      it "assigns updates vector with default length if given just a value" do
+        @df[:c] = 1.0
+        expect(@df[:c]).to eq(Daru::Vector.new([1.0, 1.0, 1.0, 1.0, 1.0],
+        index: [:one, :two, :three, :four, :five], name: :c))
+      end
+
       it "appends an Array as a Daru::Vector" do
         @df[:d] = [69,99,108,85,49]
 

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -530,7 +530,7 @@ describe Daru::DataFrame do
         index: [:one, :two, :three, :four, :five], name: :d))
       end
 
-      it "assigns updates vector with default length if given just a value" do
+      it "updates vector with default length if given just a value" do
         @df[:c] = 1.0
         expect(@df[:c]).to eq(Daru::Vector.new([1.0, 1.0, 1.0, 1.0, 1.0],
         index: [:one, :two, :three, :four, :five], name: :c))


### PR DESCRIPTION
https://github.com/SciRuby/daru/issues/351

Enable:

```
df = Daru::DataFrame.new({a: [1, 2, 3], b: [10, 20, 30]})
=> #<Daru::DataFrame(3x2)>
       a   b
   0   1  10
   1   2  20
   2   3  30

df[:c] = 1.0
=> #<Daru::DataFrame(3x3)>
       a   b   c
   0   1  10  1.0 
   1   2  20  1.0
   2   3  30  1.0

df[:a] = 1.0
=> #<Daru::DataFrame(3x3)>
       a   b   c
   0   1.0  10  1.0 
   1   1.0  20  1.0
   2   1.0  30  1.0
```