### PR TITLE
Fix insert enumerable

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2310,10 +2310,9 @@ module Daru
     end
 
     def prepare_for_insert name, arg
-      case arg
-      when Daru::Vector
+      if arg.is_a? Daru::Vector
         prepare_vector_for_insert name, arg
-      when Array, Range
+      elsif arg.respond_to?(:to_a)
         prepare_enum_for_insert name, arg
       else
         prepare_value_for_insert name, arg

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -542,6 +542,13 @@ describe Daru::DataFrame do
         expect(@df.d.class).to eq(Daru::Vector)
       end
 
+      it "appends an arbitrary enumerable as a Daru::Vector" do
+        @df[:d] = Set.new([69,99,108,85,49])
+
+        expect(@df[:d]).to eq(Daru::Vector.new([69, 99, 108, 85, 49],
+        index: [:one, :two, :three, :four, :five], name: :c))
+      end
+
       it "replaces an already present vector" do
         @df[:a] = [69,99,108,85,49].dv(nil, [:one, :two, :three, :four, :five])
 


### PR DESCRIPTION
What if value assigned is Enumerable, but is not Array or Range? (Say, it is ActiveRecord::Relation.) What user expects is it would be converted to_a, and then inserted as a vector. What actually will happen, is pretty obscure error:

when Array, Range would be skipped;
in prepare_value_for_insert, there would be called Array(relation), which will do to_a (producing array of objects)... and then multiplied by DF size, producing vector much larger than expected.