### PR TITLE
bugfix for Vector#proportions, make it return float value

### DIFF
--- a/lib/daru/maths/statistics/vector.rb
+++ b/lib/daru/maths/statistics/vector.rb
@@ -205,7 +205,7 @@ module Daru
         def proportions
           len = size - count_values(*Daru::MISSING_VALUES)
           frequencies.to_h.each_with_object({}) do |(el, count), hash|
-            hash[el] = count / len
+            hash[el] = count / len.to_f
           end
         end
 

--- a/spec/maths/statistics/vector_spec.rb
+++ b/spec/maths/statistics/vector_spec.rb
@@ -299,7 +299,11 @@ describe Daru::Vector do
 
       context "#proportions" do
         it "calculates proportions" do
-          @dv.proportions
+          actual_proportions = {
+            array: {323=>0.1,11=>0.1,555=>0.1,666=>0.2,234=>0.1,21=>0.1,343=>0.1,1=>0.1,2=>0.1},
+            gsl: {323.0=>0.1, 11.0=>0.1, 555.0=>0.1, 666.0=>0.2, 234.0=>0.1, 21.0=>0.1, 343.0=>0.1, 1.0=>0.1, 2.0=>0.1}
+          }
+          expect(@dv.proportions).to eq(actual_proportions[dtype])
         end
       end
 


### PR DESCRIPTION
bugfix for Vector#proportions, make it return float value