### PR TITLE
[WIP]add test for Daru::DataFrame "#to_category": it can add_row after to_category

### DIFF
--- a/spec/category_spec.rb
+++ b/spec/category_spec.rb
@@ -1605,6 +1605,11 @@ describe Daru::DataFrame, "categorical" do
     it { is_expected.to be_a Daru::DataFrame }
     its(:'b.type') { is_expected.to eq :category }
     its(:'c.type') { is_expected.to eq :category }
+
+    it "can add_row after to_category" do
+      new_row = df.add_row [1, 'first', 'a']
+      expect(new_row).not_to eq nil
+    end
   end
 
   context "#interact_code" do


### PR DESCRIPTION
Here is the failure details of test:

```
Failures:

  1) Daru::DataFrame categorical #to_category can add_row after to_category
     Failure/Error: (new_index.size - @index.size).times { @data << val }
     
     NoMethodError:
       undefined method `<<' for nil:NilClass
     # ./lib/daru/vector.rb:1574:in `block in insert_vector'
     # ./lib/daru/vector.rb:1574:in `times'
     # ./lib/daru/vector.rb:1574:in `insert_vector'
     # ./lib/daru/vector.rb:1587:in `set'
     # ./lib/daru/dataframe.rb:2350:in `block in insert_or_modify_row'
     # ./lib/daru/dataframe.rb:2349:in `each'
     # ./lib/daru/dataframe.rb:2349:in `each_with_index'
     # ./lib/daru/dataframe.rb:2349:in `insert_or_modify_row'
     # ./lib/daru/dataframe.rb:2172:in `dispatch_to_axis'
     # ./lib/daru/dataframe.rb:521:in `[]='
     # ./lib/daru/accessors/dataframe_by_row.rb:13:in `[]='
     # ./lib/daru/dataframe.rb:525:in `add_row'
     # ./spec/category_spec.rb:1610:in `block (3 levels) in <top (required)>'


```
the `@data` is nil after calling `dv.to_category`

I found this bug, but it is out of my knowledge of daru's source codes,  I'm not sure how to fix it.
Someone can fix it? 
Or point out some key tips I can have a try.
