### PR TITLE
Remove "backports"

### DIFF
--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -124,5 +124,3 @@ require 'daru/core/merge.rb'
 
 require 'daru/date_time/offsets.rb'
 require 'daru/date_time/index.rb'
-
-require 'backports'


### PR DESCRIPTION
Looks like `backports` is not necessary now (was for Ruby 1.9 compatibility) AND causes some really weird bugs like https://github.com/SciRuby/daru/issues/393