### PR TITLE
add which_dsl extension: use `which{ }` method as query DSL for accessing `where()`

### DIFF
--- a/lib/daru/extensions/which_dsl.rb
+++ b/lib/daru/extensions/which_dsl.rb
@@ -1,0 +1,55 @@
+# Support for a simple query DSL for accessing where(), inspired by gem "squeel"
+
+module Daru
+  class DataFrame
+    # a simple query DSL for accessing where(), inspired by gem "squeel"
+    # e.g.:
+    # df.which{ `FamilySize` == `FamilySize`.max }
+    # equals
+    # df.where( df['FamilySize'].eq( df['FamilySize'].max ) )
+    #
+    # e.g.:
+    # df.which{ (`NameTitle` == 'Dr') & (`Sex` == 'female') }
+    # equals
+    # df.where( df['NameTitle'].eq('Dr') & df['Sex'].eq('female') )
+    def which(&block)
+      WhichQuery.new(self, &block).exec
+    end
+  end
+
+  class WhichQuery
+    def initialize(df, &condition)
+      @df = df
+      @condition = condition
+    end
+
+    # executes a block of DSL code
+    def exec
+      query = instance_eval(&@condition)
+      @df.where(query)
+    end
+
+    def `(vector_name)
+      if !@df.has_vector?(vector_name) && @df.has_vector?(vector_name.to_sym)
+        vector_name = vector_name.to_sym
+      end
+      VectorWrapper.new(@df[vector_name])
+    end
+
+    class VectorWrapper < SimpleDelegator
+      {
+        :== => :eq,
+        :!= => :not_eq,
+        :<  => :lt,
+        :<= => :lteq,
+        :>  => :mt,
+        :>= => :mteq,
+        :=~ => :in
+      }.each do |opt, method|
+        define_method opt do |*args|
+          send(method, *args)
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/which_dsl_spec.rb
+++ b/spec/extensions/which_dsl_spec.rb
@@ -1,0 +1,38 @@
+require 'daru/extensions/which_dsl'
+
+describe "which DSL" do
+  before do
+    @df = Daru::DataFrame.new({
+      number: [1,2,3,4,5,6,Float::NAN],
+      sym: [:one, :two, :three, :four, :five, :six, :seven],
+      names: ['sameer', 'john', 'james', 'omisha', 'priyanka', 'shravan',nil]
+    })
+  end
+
+  it "accepts simple single eq statement" do
+    answer = Daru::DataFrame.new({
+      number: [4],
+      sym: [:four],
+      names: ['omisha']
+      }, index: Daru::Index.new([3])
+    )
+    expect( @df.which{ `number` == 4 } ).to eq(answer)
+  end
+
+  it "accepts somewhat complex comparison operator chaining" do
+    answer = Daru::DataFrame.new({
+      number: [3,4],
+      sym: [:three, :four],
+      names: ['james', 'omisha']
+    }, index: Daru::Index.new([2,3]))
+    expect(
+      @df.which{ (`names` == 'james') | (`sym` == :four) }
+      ).to eq(answer)
+  end
+
+  it "accepts vector methods" do
+    # expect( @df.which{ `number` == `number`.only_valid.max } ).to eq(@df.row_at(5)) # row_at(5) return a Vector object!?
+    expect( @df.which{ `number` <= `number`.only_valid.max } ).to eq(@df.row_at(0..5))
+  end
+
+end


### PR DESCRIPTION
add a simple query DSL for accessing where(), inspired by gem "squeel"
e.g.:

```
df.which{ `FamilySize` == `FamilySize`.max }`
```

equals

```
df.where( df['FamilySize'].eq( df['FamilySize'].max ) )
```

e.g.:

```
df.which{ (`NameTitle` == 'Dr') & (`Sex` == 'female') }
```

equals

```
df.where( df['NameTitle'].eq('Dr') & df['Sex'].eq('female') )
```

btw, repeating `df` variable is NOT DRY at all to me.
