### PR TITLE
Issue 391 vector sum skipnil

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1272,11 +1272,16 @@ module Daru
 
     # Returns a vector with sum of all vectors specified in the argument.
     # If vecs parameter is empty, sum all numeric vector.
-    def vector_sum vecs=nil
+    def vector_sum vecs=nil, opts={skipnil: false}
       vecs ||= numeric_vectors
       sum = Daru::Vector.new [0]*@size, index: @index, name: @name, dtype: @dtype
-
-      vecs.inject(sum) { |memo, n| memo + self[n] }
+      vecs.inject(sum) do |memo, n|
+        if opts[:skipnil]
+          self[n].add_skipnils(memo)
+        else
+          memo + self[n]
+        end
+      end
     end
 
     # Calculate mean of the rows of the dataframe.

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1323,13 +1323,7 @@ module Daru
 
       vecs ||= numeric_vectors
       sum = Daru::Vector.new [0]*@size, index: @index, name: @name, dtype: @dtype
-      vecs.inject(sum) do |memo, n|
-        if skipnil
-          self[n].add_skipnil(memo)
-        else
-          memo + self[n]
-        end
-      end
+      vecs.inject(sum) { |memo, n| self[n].add(memo, skipnil: skipnil) }
     end
 
     # Calculate mean of the rows of the dataframe.

--- a/lib/daru/maths/arithmetic/vector.rb
+++ b/lib/daru/maths/arithmetic/vector.rb
@@ -59,7 +59,7 @@ module Daru
         #          2 nil
         #          3 nil
         #
-        #    irb> v0.add v1
+        #    irb> v0.add v1, skipnil: true
         #    =>  #<Daru::Vector(4)>
         #          0   3
         #          1   3

--- a/lib/daru/maths/arithmetic/vector.rb
+++ b/lib/daru/maths/arithmetic/vector.rb
@@ -42,6 +42,18 @@ module Daru
           recode { |e| e.round(precision) unless e.nil? }
         end
 
+        # Add specified vector. Treat nil as 0.
+        #
+        # @example
+        #
+        #    v0 = Daru::Vector.new [1, 2, nil]
+        #    v1 = Daru::Vector.new [2, 1, 3]
+        #    irb> v0.add_skipnil v1
+        #    => #<Daru::Vector(3)>
+        #       0   3
+        #       1   3
+        #       2   3
+        #
         def add_skipnil other
           index = (@index.to_a | other.index.to_a)
           elements = index.map do |idx|

--- a/lib/daru/maths/arithmetic/vector.rb
+++ b/lib/daru/maths/arithmetic/vector.rb
@@ -42,6 +42,18 @@ module Daru
           recode { |e| e.round(precision) unless e.nil? }
         end
 
+        def add_skipnils other
+          index = (@index.to_a | other.index.to_a)
+          elements = index.map do |idx|
+            this = self.index.include?(idx) ? self[idx] : nil
+            that = other.index.include?(idx) ? other[idx] : nil
+            this = 0 if this.nil?
+            that = 0 if that.nil?
+            this && that ? this + that : nil
+          end
+          Daru::Vector.new(elements, name: @name, index: index)
+        end
+
         private
 
         def math_unary_op operation

--- a/lib/daru/maths/arithmetic/vector.rb
+++ b/lib/daru/maths/arithmetic/vector.rb
@@ -42,7 +42,7 @@ module Daru
           recode { |e| e.round(precision) unless e.nil? }
         end
 
-        def add_skipnils other
+        def add_skipnil other
           index = (@index.to_a | other.index.to_a)
           elements = index.map do |idx|
             this = self.index.include?(idx) ? self[idx] : nil

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3194,6 +3194,10 @@ describe Daru::DataFrame do
       expect(@df.vector_sum).to eq(Daru::Vector.new [nil, 15, 26, nil, 28, nil])
     end
 
+    it "ignores nils if skipnil is true" do
+      expect(@df.vector_sum(nil, skipnil: true)).to eq(Daru::Vector.new [13, 15, 26, 25, 28, 35])
+    end
+
     it "calculates partial vector sum" do
       a = @df.vector_sum([:a1, :a2])
       b = @df.vector_sum([:b1, :b2])

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3198,6 +3198,10 @@ describe Daru::DataFrame do
       expect(@df.vector_sum skipnil: true).to eq(Daru::Vector.new [13, 15, 26, 25, 28, 35])
     end
 
+    it "ignores nils vectors are specified and skipnil is true" do
+      expect(@df.vector_sum [:a1, :b1], skipnil: true).to eq(Daru::Vector.new [1, 3, 4, 5, 6, 2])
+    end
+
     it "calculates partial vector sum" do
       a = @df.vector_sum([:a1, :a2])
       b = @df.vector_sum([:b1, :b2])

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3195,7 +3195,7 @@ describe Daru::DataFrame do
     end
 
     it "ignores nils if skipnil is true" do
-      expect(@df.vector_sum(nil, skipnil: true)).to eq(Daru::Vector.new [13, 15, 26, 25, 28, 35])
+      expect(@df.vector_sum skipnil: true).to eq(Daru::Vector.new [13, 15, 26, 25, 28, 35])
     end
 
     it "calculates partial vector sum" do

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3183,31 +3183,27 @@ describe Daru::DataFrame do
 
   context "#vector_sum" do
     before do
-      a1 = Daru::Vector.new [1, 2, 3, 4, 5, nil]
-      a2 = Daru::Vector.new [10, 10, 20, 20, 20, 30]
-      b1 = Daru::Vector.new [nil, 1, 1, 1, 1, 2]
-      b2 = Daru::Vector.new [2, 2, 2, nil, 2, 3]
+      a1 = Daru::Vector.new [1, 2, 3, 4, 5, nil, nil]
+      a2 = Daru::Vector.new [10, 10, 20, 20, 20, 30, nil]
+      b1 = Daru::Vector.new [nil, 1, 1, 1, 1, 2, nil]
+      b2 = Daru::Vector.new [2, 2, 2, nil, 2, 3, nil]
       @df = Daru::DataFrame.new({ :a1 => a1, :a2 => a2, :b1 => b1, :b2 => b2 })
     end
 
     it "calculates complete vector sum" do
-      expect(@df.vector_sum).to eq(Daru::Vector.new [nil, 15, 26, nil, 28, nil])
+      expect(@df.vector_sum).to eq(Daru::Vector.new [nil, 15, 26, nil, 28, nil, nil])
     end
 
     it "ignores nils if skipnil is true" do
-      expect(@df.vector_sum skipnil: true).to eq(Daru::Vector.new [13, 15, 26, 25, 28, 35])
-    end
-
-    it "ignores nils vectors are specified and skipnil is true" do
-      expect(@df.vector_sum [:a1, :b1], skipnil: true).to eq(Daru::Vector.new [1, 3, 4, 5, 6, 2])
+      expect(@df.vector_sum skipnil: true).to eq(Daru::Vector.new [13, 15, 26, 25, 28, 35, 0])
     end
 
     it "calculates partial vector sum" do
       a = @df.vector_sum([:a1, :a2])
       b = @df.vector_sum([:b1, :b2])
 
-      expect(a).to eq(Daru::Vector.new [11, 12, 23, 24, 25, nil])
-      expect(b).to eq(Daru::Vector.new [nil, 3, 3, nil, 3, 5])
+      expect(a).to eq(Daru::Vector.new [11, 12, 23, 24, 25, nil, nil])
+      expect(b).to eq(Daru::Vector.new [nil, 3, 3, nil, 3, 5, nil])
     end
   end
 

--- a/spec/maths/arithmetic/vector_spec.rb
+++ b/spec/maths/arithmetic/vector_spec.rb
@@ -78,13 +78,22 @@ describe Daru::Vector do
     end
   end
 
-  context "#add_skipnil" do
-    it "adds two vectors assuming nils to be zeros" do
-      expect(@with_md1.add_skipnil(@with_md2)).to eq(Daru::Vector.new(
-        [1, 7, 3, 1, 7, 3],
+  context "#add" do
+
+    it "adds two vectors with nils as 0 if skipnil is true" do
+      expect(@with_md1.add(@with_md2, skipnil: true)).to eq(Daru::Vector.new(
+        [1, 7, 3, 3, 1, 7],
         name: :missing,
-        index: [:a, :b, :c, :obi, :wan, :corona]))
+        index: [:a, :b, :c, :corona, :obi, :wan]))
     end
+
+    it "adds two vectors same as :+ if skipnil is false" do
+      expect(@with_md1.add(@with_md2, skipnil: false)).to eq(Daru::Vector.new(
+        [nil, 7, nil, nil, nil, 7],
+        name: :missing,
+        index: [:a, :b, :c, :corona, :obi, :wan]))
+    end
+
   end
 
   context "#abs" do

--- a/spec/maths/arithmetic/vector_spec.rb
+++ b/spec/maths/arithmetic/vector_spec.rb
@@ -78,6 +78,15 @@ describe Daru::Vector do
     end
   end
 
+  context "#add_skipnils" do
+    it "adds two vectors assuming nils to be zeros" do
+      expect(@with_md1.add_skipnils(@with_md2)).to eq(Daru::Vector.new(
+        [1, 7, 3, 1, 7, 3],
+        name: :missing,
+        index: [:a, :b, :c, :obi, :wan, :corona]))
+    end
+  end
+
   context "#abs" do
     it "calculates abs value" do
       @with_md1.abs

--- a/spec/maths/arithmetic/vector_spec.rb
+++ b/spec/maths/arithmetic/vector_spec.rb
@@ -78,9 +78,9 @@ describe Daru::Vector do
     end
   end
 
-  context "#add_skipnils" do
+  context "#add_skipnil" do
     it "adds two vectors assuming nils to be zeros" do
-      expect(@with_md1.add_skipnils(@with_md2)).to eq(Daru::Vector.new(
+      expect(@with_md1.add_skipnil(@with_md2)).to eq(Daru::Vector.new(
         [1, 7, 3, 1, 7, 3],
         name: :missing,
         index: [:a, :b, :c, :obi, :wan, :corona]))


### PR DESCRIPTION
Adds support for `skipnil` flag as discussed in issue #391 . There is some common code between `add_skipnil` and `v2v_binary` but I decided to keep these two separate to avoid performance penalty for all binary operation to support one scenario of `vector_sum` with `skipnil`. Suggestions welcome.