### PR TITLE
#198 - Add rolling_fillna method to Daru::Dataframe and Daru::Vector

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -661,6 +661,52 @@ module Daru
       self
     end
 
+    # Rolling fillna
+    # replace all Float::NAN and NIL values with the preceeding or following value
+    #
+    # @param [Symbol] (:forward, :backward) whether replacement value is preceeding or following
+    #
+    # @example
+    #
+    # df = Daru::DataFrame.new({
+    #  a: [1,    2,          3,   nil,        Float::NAN, nil, 1,   7],
+    #  b: [:a,  :b,          nil, Float::NAN, nil,        3,   5,   nil],
+    #  c: ['a',  Float::NAN, 3,   4,          3,          5,   nil, 7]
+    # })
+    #
+    # => #<Daru::DataFrame(8x3)>
+    #      a   b   c
+    #  0   1   a   a
+    #  1   2   b NaN
+    #  2   3 nil   3
+    #  3 nil NaN   4
+    #  4 NaN nil   3
+    #  5 nil   3   5
+    #  6   1   5 nil
+    #  7   7 nil   7
+    #
+    # 2.3.3 :068 > df.rolling_fillna(:forward)
+    # => #<Daru::DataFrame(8x3)>
+    #      a   b   c
+    #  0   1   a   a
+    #  1   2   b   a
+    #  2   3   b   3
+    #  3   3   b   4
+    #  4   3   b   3
+    #  5   3   3   5
+    #  6   1   5   5
+    #  7   7   5   7
+    #
+    def rolling_fillna!(direction=:forward)
+      @data.each { |vec| vec.rolling_fillna!(direction) }
+    end
+
+    def rolling_fillna(direction=:forward)
+      dup.tap do |df|
+        df.each_vector { |vec| vec.rolling_fillna!(direction) }
+      end
+    end
+
     # Iterate over each index of the DataFrame.
     def each_index &block
       return to_enum(:each_index) unless block_given?

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -702,9 +702,7 @@ module Daru
     end
 
     def rolling_fillna(direction=:forward)
-      dup.tap do |df|
-        df.each_vector { |vec| vec.rolling_fillna!(direction) }
-      end
+      dup.rolling_fillna!(direction)
     end
 
     # Iterate over each index of the DataFrame.

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -784,14 +784,9 @@ module Daru
     def rolling_fillna!(direction=:forward)
       missing_idxs = indexes(*Daru::MISSING_VALUES)
       valid_idxs = Array(0...dv.size) - missing_idxs
-      if (direction == :forward)
-        valid_idxs = valid_idxs.reverse
-        comparator = :<
-      else
-        comparator = :>
-      end
+      valid_idxs, comp = (direction == :forward) ? [valid_idxs.reverse, :<] : [valid_idxs, :>]
       missing_idxs.each do |idx|
-        repl_idx = valid_idxs.find { |i| i.public_send(comparator, idx) }
+        repl_idx = valid_idxs.find { |i| i.public_send(comp, idx) }
         repl = repl_idx ? self[repl_idx] : 0
         self[idx] = repl
       end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -794,7 +794,7 @@ module Daru
 
     # Non-destructive version of rolling_fillna!
     def rolling_fillna(direction=:forward)
-      dup.rolling_fillna!
+      dup.rolling_fillna!(direction)
     end
 
     # Lags the series by `k` periods.

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -760,6 +760,44 @@ module Daru
       self
     end
 
+    # Rolling fillna
+    # replace all Float::NAN and NIL values with the preceeding or following value
+    #
+    # @param [Symbol] (:forward, :backward) whether replacement value is preceeding or following
+    #
+    # @example
+    #
+    # dv = Daru::Vector.new([1, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN])
+    #
+    # 2.3.3 :068 > dv.rolling_fillna(:forward)
+    # => #<Daru::Vector(9)>
+    # 0   1
+    # 1   2
+    # 2   1
+    # 3   4
+    # 4   4
+    # 5   4
+    # 6   3
+    # 7   3
+    # 8   3
+    #
+    def rolling_fillna!(direction=:forward)
+      missing_idxs = indexes(*Daru::MISSING_VALUES)
+      missing_idxs.each do |idx|
+        repl_idx = idx
+        while (missing_idxs.include?(repl_idx) && (repl_idx > -2 || repl_idx <= self.size))
+          repl_idx = direction == :forward ? repl_idx - 1 : repl_idx + 1
+        end
+        repl = (repl_idx == -1 || repl_idx == self.size) ? 0 : self[repl_idx]
+        self[idx] = repl
+      end
+    end
+
+    # Non-destructive version of rolling_fillna!
+    def rolling_fillna(direction=:forward)
+      dup.rolling_fillna!
+    end
+
     # Lags the series by `k` periods.
     #
     # Lags the series by `k` periods, "shifting" data and inserting `nil`s

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -783,12 +783,11 @@ module Daru
     #
     def rolling_fillna!(direction=:forward)
       missing_idxs = indexes(*Daru::MISSING_VALUES)
+      valid_idxs = Array(0...dv.size) - missing_idxs
+      valid_idxs = (direction == :forward) ? valid_idxs.reverse : valid_idxs
       missing_idxs.each do |idx|
-        repl_idx = idx
-        while (missing_idxs.include?(repl_idx) && (repl_idx > -2 || repl_idx <= self.size))
-          repl_idx = direction == :forward ? repl_idx - 1 : repl_idx + 1
-        end
-        repl = (repl_idx == -1 || repl_idx == self.size) ? 0 : self[repl_idx]
+        repl_idx = (direction == :forward) ? valid_idxs.find { |i| i < idx } : valid_idxs.find { |i| i > idx }
+        repl = repl_idx ? self[repl_idx] : 0
         self[idx] = repl
       end
     end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -788,7 +788,6 @@ module Daru
         valid_idxs = valid_idxs.reverse
         comparator = :<
       else
-        valid_idxs = valid_idxs
         comparator = :>
       end
       missing_idxs.each do |idx|

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -784,7 +784,7 @@ module Daru
     def rolling_fillna!(direction=:forward)
       missing_idxs = indexes(*Daru::MISSING_VALUES)
       valid_idxs = Array(0...dv.size) - missing_idxs
-      valid_idxs, comp = (direction == :forward) ? [valid_idxs.reverse, :<] : [valid_idxs, :>]
+      valid_idxs, comp = direction == :forward ? [valid_idxs.reverse, :<] : [valid_idxs, :>]
       missing_idxs.each do |idx|
         repl_idx = valid_idxs.find { |i| i.public_send(comp, idx) }
         repl = repl_idx ? self[repl_idx] : 0

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -784,9 +784,15 @@ module Daru
     def rolling_fillna!(direction=:forward)
       missing_idxs = indexes(*Daru::MISSING_VALUES)
       valid_idxs = Array(0...dv.size) - missing_idxs
-      valid_idxs = (direction == :forward) ? valid_idxs.reverse : valid_idxs
+      if (direction == :forward)
+        valid_idxs = valid_idxs.reverse
+        comparator = :<
+      else
+        valid_idxs = valid_idxs
+        comparator = :>
+      end
       missing_idxs.each do |idx|
-        repl_idx = (direction == :forward) ? valid_idxs.find { |i| i < idx } : valid_idxs.find { |i| i > idx }
+        repl_idx = valid_idxs.find { |i| i.public_send(comparator, idx) }
         repl = repl_idx ? self[repl_idx] : 0
         self[idx] = repl
       end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1475,7 +1475,7 @@ module Daru
         end
     end
 
-    # Helper method for rolling_fillna
+    # Helper method returning validity of arbitrary value
     def valid_value?(v)
       v.respond_to?(:nan?) && v.nan? || v.nil? ? false : true
     end

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -1797,6 +1797,32 @@ describe Daru::DataFrame do
     end
   end
 
+  context '#rolling_fillna!' do
+    subject do
+      Daru::DataFrame.new({
+        a: [1,    2,          3,   nil,        Float::NAN, nil, 1,   7],
+        b: [:a,  :b,          nil, Float::NAN, nil,        3,   5,   nil],
+        c: ['a',  Float::NAN, 3,   4,          3,          5,   nil, 7]
+      })
+    end
+
+    context 'rolling_fillna! forwards' do
+      before { subject.rolling_fillna!(:forward) }
+      it { is_expected.to be_a Daru::DataFrame }
+      its(:'a.to_a') { is_expected.to eq [1, 2, 3, 3, 3, 3, 1, 7] }
+      its(:'b.to_a') { is_expected.to eq [:a,  :b, :b, :b, :b, 3, 5, 5] }
+      its(:'c.to_a') { is_expected.to eq ['a', 'a', 3, 4, 3, 5, 5, 7] }
+    end
+
+    context 'rolling_fillna! backwards' do
+      before { subject.rolling_fillna!(:backward) }
+      it { is_expected.to be_a Daru::DataFrame }
+      its(:'a.to_a') { is_expected.to eq [1, 2, 3, 1, 1, 1, 1, 7] }
+      its(:'b.to_a') { is_expected.to eq [:a, :b, 3, 3, 3, 3, 5, 0] }
+      its(:'c.to_a') { is_expected.to eq ['a', 3, 3, 4, 3, 5, 7, 7] }
+    end
+  end
+
   context "#clone" do
     it "returns a view of the whole dataframe" do
       cloned = @data_frame.clone

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1795,6 +1795,17 @@ describe Daru::Vector do
       before { subject.rolling_fillna!(:forward) }
       its(:to_a) { is_expected.to eq [0, 0, 0, 0, 0] }
     end
+
+    context 'with non-default index' do
+      subject do
+        Daru::Vector.new(
+          [Float::NAN, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN],
+          index: %w[a b c d e f g h i]
+        )
+      end
+      before { subject.rolling_fillna!(direction: :backward) }
+      it { is_expected.to eq Daru::Vector.new([2, 2, 1, 4, 3, 3, 3, 0, 0], index: %w[a b c d e f g h i]) }
+    end
   end
 
   context "#type" do

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1769,6 +1769,24 @@ describe Daru::Vector do
     end
   end
 
+  context '#rolling_fillna!' do
+    subject do
+      Daru::Vector.new(
+        [1, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN]
+      )
+    end
+
+    context 'rolling_fillna! forwards' do
+      before { subject.rolling_fillna!(:forward) }
+      its(:to_a) { is_expected.to eq [1, 2, 1, 4, 4, 4, 3, 3, 3] }
+    end
+
+    context 'rolling_fillna! backwards' do
+      before { subject.rolling_fillna!(dir: :backward) }
+      its(:to_a) { is_expected.to eq [1, 2, 1, 4, 3, 3, 3, 0, 0] }
+    end
+  end
+
   context "#type" do
     before(:each) do
       @numeric    = Daru::Vector.new([1,2,3,4,5])

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1772,18 +1772,28 @@ describe Daru::Vector do
   context '#rolling_fillna!' do
     subject do
       Daru::Vector.new(
-        [1, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN]
+        [Float::NAN, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN]
       )
     end
 
     context 'rolling_fillna! forwards' do
       before { subject.rolling_fillna!(:forward) }
-      its(:to_a) { is_expected.to eq [1, 2, 1, 4, 4, 4, 3, 3, 3] }
+      its(:to_a) { is_expected.to eq [0, 2, 1, 4, 4, 4, 3, 3, 3] }
     end
 
     context 'rolling_fillna! backwards' do
       before { subject.rolling_fillna!(direction: :backward) }
-      its(:to_a) { is_expected.to eq [1, 2, 1, 4, 3, 3, 3, 0, 0] }
+      its(:to_a) { is_expected.to eq [2, 2, 1, 4, 3, 3, 3, 0, 0] }
+    end
+
+    context 'all invalid vector' do
+      subject do
+        Daru::Vector.new(
+          [Float::NAN, Float::NAN, Float::NAN, Float::NAN, Float::NAN]
+        )
+      end
+      before { subject.rolling_fillna!(:forward) }
+      its(:to_a) { is_expected.to eq [0, 0, 0, 0, 0] }
     end
   end
 

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1782,7 +1782,7 @@ describe Daru::Vector do
     end
 
     context 'rolling_fillna! backwards' do
-      before { subject.rolling_fillna!(dir: :backward) }
+      before { subject.rolling_fillna!(direction: :backward) }
       its(:to_a) { is_expected.to eq [1, 2, 1, 4, 3, 3, 3, 0, 0] }
     end
   end


### PR DESCRIPTION
https://github.com/SciRuby/daru/issues/198

Initial attempt at implementing a rolling fillna function. Straight forward replace with scalar value is not implemented since we already have `replace_values` function to do that. This just allows you to fill all Nil or NAN values with the last valid preceding or next valid following value.