### PR TITLE
#407 - Preserve key/column order when initialising a DataFrame from hash

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2454,7 +2454,7 @@ module Daru
     end
 
     def create_vectors_index_with vectors, source
-      vectors = source.keys.sort_by(&:to_s) if vectors.nil?
+      vectors = source.keys if vectors.nil?
 
       @vectors =
         if vectors.is_a?(Index) || vectors.is_a?(MultiIndex)

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -171,6 +171,13 @@ describe Daru::DataFrame do
         expect(df.a)      .to eq([1,2,3,4,5].dv(:a, df.index))
       end
 
+      it "initializes from a Hash and preserves default order" do
+        df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]},
+          index: [:one, :two, :three, :four, :five])
+
+        expect(df.vectors).to eq(Daru::Index.new [:b, :a])
+      end
+
       it "initializes from a Hash of Vectors" do
         va = Daru::Vector.new([1,2,3,4,5], index: [:one, :two, :three, :four, :five])
         vb = Daru::Vector.new([11,12,13,14,15], index: [:one, :two, :three, :four, :five])
@@ -228,7 +235,7 @@ describe Daru::DataFrame do
         df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]})
 
         expect(df.index)  .to eq(Daru::Index.new [0,1,2,3,4])
-        expect(df.vectors).to eq(Daru::Index.new [:a, :b])
+        expect(df.vectors).to eq(Daru::Index.new [:b, :a])
       end
 
       it "aligns indexes properly" do
@@ -3391,7 +3398,8 @@ describe Daru::DataFrame do
       ev_b  = Daru::Vector.new [1, 1, 0]
       ev_c  = Daru::Vector.new [0, 1, 1]
       df2 = Daru::DataFrame.new({
-        :_id => ev_id, 'a' => ev_a, 'b' => ev_b, 'c' => ev_c })
+        :_id => ev_id, 'a' => ev_a, 'b' => ev_b, 'c' => ev_c },
+        order: ['a', 'b', 'c', :_id])
 
       expect(df2).to eq(df)
     end

--- a/spec/io/io_spec.rb
+++ b/spec/io/io_spec.rb
@@ -13,8 +13,8 @@ describe Daru::IO do
         df = Daru::DataFrame.from_csv('spec/fixtures/matrix_test.csv',
           col_sep: ' ', headers: true)
 
-        df.vectors = [:image_resolution, :mls, :true_transform].to_index
-        expect(df.vectors).to eq([:image_resolution, :mls, :true_transform].to_index)
+        df.vectors = [:image_resolution, :true_transform, :mls].to_index
+        expect(df.vectors).to eq([:image_resolution, :true_transform, :mls].to_index)
         expect(df[:image_resolution].first).to eq(6.55779)
         expect(df[:true_transform].first).to eq("-0.2362347,0.6308649,0.7390552,0,0.6523478,-0.4607318,0.6018043,0,0.7201635,0.6242881,-0.3027024,4262.65,0,0,0,1")
       end


### PR DESCRIPTION
https://github.com/SciRuby/daru/issues/407