### PR TITLE
Support calling GroupBy#each_group w/o blocks

### DIFF
--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -6,6 +6,8 @@ module Daru
       # Iterate over each group created by group_by. A DataFrame is yielded in
       # block.
       def each_group
+        return to_enum(:each_group) unless block_given?
+
         groups.keys.each do |k|
           yield get_group(k)
         end

--- a/spec/core/group_by_spec.rb
+++ b/spec/core/group_by_spec.rb
@@ -201,6 +201,22 @@ describe Daru::Core::GroupBy do
     end
   end
 
+  context '#each_group without block' do
+    it 'enumerates groups' do
+      enum = @dl_group.each_group
+
+      expect(enum.count).to eq 6
+      expect(enum).to all be_a(Daru::DataFrame)
+      expect(enum.to_a.last).to eq(Daru::DataFrame.new({
+        a: ['foo', 'foo'],
+        b: ['two', 'two'],
+        c: [3, 3],
+        d: [33, 55]
+        }, index: [2, 4]
+      ))
+    end
+  end
+
   context '#first' do
     it 'gets the first row from each group' do
       expect(@dl_group.first).to eq(Daru::DataFrame.new({


### PR DESCRIPTION
Hi, I’ve had `GroupBy#each_group` without blocks return an Enumerator. Other each* methods in daru seem also returning an Enumerator. I think it looks useful and natural as Ruby. What do you think?

This may be related to #145.