### PR TITLE
allow symbol to converters option

### DIFF
--- a/lib/daru/io/io.rb
+++ b/lib/daru/io/io.rb
@@ -214,7 +214,7 @@ module Daru
       end
 
       def from_csv_prepare_converters(converters)
-        converters.flat_map do |c|
+        Array(converters).flat_map do |c|
           if ::CSV::Converters[c]
             ::CSV::Converters[c]
           elsif Daru::IO::CSV::CONVERTERS[c]

--- a/spec/io/io_spec.rb
+++ b/spec/io/io_spec.rb
@@ -51,6 +51,11 @@ describe Daru::IO do
         expect(df['Domestic'].to_a).to all be_boolean
       end
 
+      it "allow symbol to converters option" do
+        df = Daru::DataFrame.from_csv 'spec/fixtures/boolean_converter_test.csv', converters: :boolean
+        expect(df['Domestic'].to_a).to all be_boolean
+      end
+
       it "checks for equal parsing of local CSV files and remote CSV files" do
         %w[matrix_test repeated_fields scientific_notation sales-funnel].each do |file|
           df_local  = Daru::DataFrame.from_csv("spec/fixtures/#{file}.csv")


### PR DESCRIPTION
CSV.new is allow only symbol converters option.

> A single converter doesn't have to be in an Array.

from https://ruby-doc.org/stdlib-2.4.2/libdoc/csv/rdoc/CSV.html