### PR TITLE
rolling_fillna! bugfixes on Daru::Vector and Daru::DataFrame

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -698,6 +698,7 @@ module Daru
     #
     def rolling_fillna!(direction=:forward)
       @data.each { |vec| vec.rolling_fillna!(direction) }
+      self
     end
 
     def rolling_fillna(direction=:forward)

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -790,6 +790,7 @@ module Daru
           self[idx] = last_valid_value
         end
       end
+      self
     end
 
     # Non-destructive version of rolling_fillna!

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -1858,7 +1858,7 @@ describe Daru::DataFrame do
 
     context 'rolling_fillna! forwards' do
       before { subject.rolling_fillna!(:forward) }
-      it { is_expected.to be_a Daru::DataFrame }
+      it { expect(subject.rolling_fillna!(:forward)).to eq(subject) }
       its(:'a.to_a') { is_expected.to eq [1, 2, 3, 3, 3, 3, 1, 7] }
       its(:'b.to_a') { is_expected.to eq [:a,  :b, :b, :b, :b, 3, 5, 5] }
       its(:'c.to_a') { is_expected.to eq ['a', 'a', 3, 4, 3, 5, 5, 7] }
@@ -1866,7 +1866,7 @@ describe Daru::DataFrame do
 
     context 'rolling_fillna! backwards' do
       before { subject.rolling_fillna!(:backward) }
-      it { is_expected.to be_a Daru::DataFrame }
+      it { expect(subject.rolling_fillna!(:backward)).to eq(subject) }
       its(:'a.to_a') { is_expected.to eq [1, 2, 3, 1, 1, 1, 1, 7] }
       its(:'b.to_a') { is_expected.to eq [:a, :b, 3, 3, 3, 3, 5, 0] }
       its(:'c.to_a') { is_expected.to eq ['a', 3, 3, 4, 3, 5, 7, 7] }

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1808,6 +1808,22 @@ describe Daru::Vector do
     end
   end
 
+  context '#rolling_fillna' do
+    subject do
+      Daru::Vector.new(
+        [Float::NAN, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN]
+      )
+    end
+
+    context 'rolling_fillna forwards' do
+      it { expect(subject.rolling_fillna(:forward).to_a).to eq [0, 2, 1, 4, 4, 4, 3, 3, 3] }
+    end
+
+    context 'rolling_fillna backwards' do
+      it { expect(subject.rolling_fillna(direction: :backward).to_a).to eq [2, 2, 1, 4, 3, 3, 3, 0, 0] }
+    end
+  end
+
   context "#type" do
     before(:each) do
       @numeric    = Daru::Vector.new([1,2,3,4,5])


### PR DESCRIPTION
According to documentation `rolling_fillna!` should return the modified object
Actually the Vector is correctly updated but it return the index! 

```ruby
dv = Daru::Vector.new([1, 2, 1, 4, nil, Float::NAN, 3, nil, Float::NAN])
dv.rolling_fillna!(:forward)
# => #<Daru::Index(9): {0, 1, 2, 3, 4, 5, 6, 7, 8}>
dv
=> #<Daru::Vector(9)>
   0   1
   1   2
   2   1
   3   4
   4   4
   5   4
   6   3
   7   3
   8   3
```

`rolling_fillna` is not working either as it clone the object before calling `rolling_fillna!` 

