### PR TITLE
Refactor grouping and aggregation

### DIFF
--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -325,20 +325,6 @@ module Daru
 
       private
 
-      def init_groups_df tuples, names
-        multi_index_tuples = []
-        keys = tuples.uniq.sort(&TUPLE_SORTER)
-        keys.each do |key|
-          indices = all_indices_for(tuples, key)
-          @groups[key] = indices
-          indices.each do |indice|
-            multi_index_tuples << key + [indice]
-          end
-        end
-        @groups.freeze
-        @df = resultant_context(multi_index_tuples, names) unless multi_index_tuples.empty?
-      end
-
       def select_groups_from method, quantity
         selection     = @context
         rows, indexes = [], []
@@ -376,33 +362,6 @@ module Daru
           Daru::MultiIndex.from_tuples(@groups.keys)
         else
           Daru::Index.new(@groups.keys.flatten)
-        end
-      end
-
-      def resultant_context(multi_index_tuples, names)
-        multi_index = Daru::MultiIndex.from_tuples(multi_index_tuples)
-        context_tmp = @context.dup.delete_vectors(*names)
-        rows_tuples = context_tmp.access_row_tuples_by_indexs(
-          *@groups.values.flatten!
-        )
-        context_new = Daru::DataFrame.rows(rows_tuples, index: multi_index)
-        context_new.vectors = context_tmp.vectors
-        context_new
-      end
-
-      def all_indices_for arry, element
-        found, index, indexes = -1, -1, []
-        while found
-          found = arry[index+1..-1].index(element)
-          if found
-            index = index + found + 1
-            indexes << index
-          end
-        end
-        if indexes.count == 1
-          [@context.index.at(*indexes)]
-        else
-          @context.index.at(*indexes).to_a
         end
       end
 

--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -335,7 +335,6 @@ module Daru
       #           Ram Hyderabad,Mumbai
       #
       def aggregate(options={})
-        @df.index = @df.index.remove_layer(@df.index.levels.size - 1)
         @df.aggregate(options)
       end
 

--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -17,6 +17,15 @@ module Daru
           group_map
         end
 
+        def get_positions_group_for_aggregation(multi_index, level=-1)
+          raise unless multi_index.is_a?(Daru::MultiIndex)
+
+          new_index = multi_index.dup
+          new_index.remove_layer(level) # TODO: recheck code of Daru::MultiIndex#remove_layer
+
+          get_positions_group_map_on(new_index.each_with_index)
+        end
+
         def get_positions_group_map_for_df(df, group_by_keys, sort: true)
           indexes_with_positions = df[*group_by_keys].to_df.each_row.map(&:to_a).each_with_index
 

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2303,7 +2303,7 @@ module Daru
     #      3   d  17
     #      4   e   1
     #
-    #    df.aggregate(num_100_times: ->(df) { df.num*100 })
+    #    df.aggregate(num_100_times: ->(df) { (df.num*100).first })
     #   => #<Daru::DataFrame(5x1)>
     #               num_100_ti
     #             0       5200
@@ -2353,12 +2353,9 @@ module Daru
     end
 
     def apply_method_on_df index_tuples, method
-      rows = []
-      index_tuples.each do |indexes|
-        slice = row[*indexes]
-        rows << method.call(slice)
+      index_tuples.map do |indexes|
+        apply_method_on_sub_df(method, keys: [*indexes], by_position: false)
       end
-      rows
     end
 
     def headers

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -549,6 +549,20 @@ module Daru
       Daru::Accessors::DataFrameByRow.new(self)
     end
 
+    # Extract a dataframe given row indexes or positions
+    # @param keys [Array] can be positions (if by_position is true) or indexes (if by_position if false)
+    # @return [Daru::Dataframe]
+    def get_sub_dataframe(keys, by_position: true)
+      return Daru::DataFrame.new({}) if keys == []
+
+      keys = @index.pos(*keys) unless by_position
+
+      sub_df = row_at(*keys)
+      sub_df = sub_df.to_df.transpose if sub_df.is_a?(Daru::Vector)
+
+      sub_df
+    end
+
     # Duplicate the DataFrame entirely.
     #
     # == Arguments
@@ -990,6 +1004,17 @@ module Daru
 
       self
     end
+
+    def apply_method(method, keys: nil, by_position: true)
+      df = keys ? get_sub_dataframe(keys, by_position: by_position) : self
+
+      case method
+      when Symbol then df.send(method)
+      when Proc   then method.call(df)
+      else raise
+      end
+    end
+    alias :apply_method_on_sub_df :apply_method
 
     # Retrieves a Daru::Vector, based on the result of calculation
     # performed on each row.

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2329,6 +2329,16 @@ module Daru
       Daru::DataFrame.new(colmn_value, index: new_index, order: options.keys)
     end
 
+    # Is faster than using group_by followed by aggregate (because it doesn't generate an intermediary dataframe)
+    def group_by_and_aggregate(*group_by_keys, **aggregation_map)
+      positions_groups = Daru::Core::GroupBy.get_positions_group_map_for_df(self, group_by_keys.flatten, sort: true)
+
+      new_index   = Daru::MultiIndex.from_tuples(positions_groups.keys).coerce_index
+      colmn_value = aggregate_by_positions_tuples(aggregation_map, positions_groups.values)
+
+      Daru::DataFrame.new(colmn_value, index: new_index, order: aggregation_map.keys)
+    end
+
     private
 
     def headers

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2927,6 +2927,22 @@ module Daru
       [colmn_value, index_tuples]
     end
 
+    def group_index_for_aggregation(index, multi_index_level=-1)
+      case index
+      when Daru::MultiIndex
+        groups = Daru::Core::GroupBy.get_positions_group_for_aggregation(index, multi_index_level)
+        new_index, pos_tuples = groups.keys, groups.values
+
+        new_index = Daru::MultiIndex.from_tuples(new_index).coerce_index
+      when Daru::Index, Daru::CategoricalIndex
+        new_index = Array(index).uniq
+        pos_tuples = new_index.map { |idx| [*index.pos(idx)] }
+      else raise
+      end
+
+      [pos_tuples, new_index]
+    end
+
     # coerce ranges, integers and array in appropriate ways
     def coerce_positions *positions, size
       if positions.size == 1

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2274,18 +2274,6 @@ module Daru
       end
     end
 
-    # returns array of row tuples at given index(s)
-    def access_row_tuples_by_indexs *indexes
-      positions = @index.pos(*indexes)
-      if positions.is_a? Numeric
-        row = populate_row_for(positions)
-        row.first.is_a?(Array) ? row : [row]
-      else
-        new_rows = @data.map { |vec| vec[*indexes] }
-        indexes.map { |index| new_rows.map { |r| r[index] } }
-      end
-    end
-
     # Function to use for aggregating the data.
     #
     # @param options [Hash] options for column, you want in resultant dataframe

--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -285,7 +285,7 @@ module Daru
     end
 
     def dup
-      MultiIndex.new levels: levels.dup, labels: labels
+      MultiIndex.new levels: levels.dup, labels: labels.dup, name: (@name.nil? ? nil : @name.dup)
     end
 
     def drop_left_level by=1

--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -244,8 +244,21 @@ module Daru
       @labels.delete_at(layer_index)
       @name.delete_at(layer_index) unless @name.nil?
 
-      # CategoricalIndex is used , to allow duplicate indexes.
-      @levels.size == 1 ? Daru::CategoricalIndex.new(to_a.flatten) : self
+      coerce_index
+    end
+
+    def coerce_index
+      if @levels.size == 1
+        elements = to_a.flatten
+
+        if elements.uniq.length == elements.length
+          Daru::Index.new(elements)
+        else
+          Daru::CategoricalIndex.new(elements)
+        end
+      else
+        self
+      end
     end
 
     # Array `name` must have same length as levels and labels.

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -122,6 +122,17 @@ module Daru
       self
     end
 
+    def apply_method(method, keys: nil, by_position: true)
+      vect = keys ? get_sub_vector(keys, by_position: by_position) : self
+
+      case method
+      when Symbol then vect.send(method)
+      when Proc   then method.call(vect)
+      else raise
+      end
+    end
+    alias :apply_method_on_sub_vector :apply_method
+
     # The name of the Daru::Vector. String.
     attr_reader :name
     # The row index. Can be either Daru::Index or Daru::MultiIndex.
@@ -869,6 +880,19 @@ module Daru
     # Returns *true* if an index exists
     def has_index? index
       @index.include? index
+    end
+
+    # @param keys [Array] can be positions (if by_position is true) or indexes (if by_position if false)
+    # @return [Daru::Vector]
+    def get_sub_vector(keys, by_position: true)
+      return Daru::Vector.new([]) if keys == []
+
+      keys = @index.pos(*keys) unless by_position
+
+      sub_vect = at(*keys)
+      sub_vect = Daru::Vector.new([sub_vect]) unless sub_vect.is_a?(Daru::Vector)
+
+      sub_vect
     end
 
     # @return [Daru::DataFrame] the vector as a single-vector dataframe

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -4055,6 +4055,34 @@ describe Daru::DataFrame do
     end
   end
 
+  context '#group_by_and_aggregate' do
+    let(:spending_df) {
+      Daru::DataFrame.rows([
+        [2010,    'dev',  50, 1],
+        [2010,    'dev', 150, 1],
+        [2010,    'dev', 200, 1],
+        [2011,    'dev',  50, 1],
+        [2012,    'dev', 150, 1],
+
+        [2011, 'office', 300, 1],
+
+        [2010, 'market',  50, 1],
+        [2011, 'market', 500, 1],
+        [2012, 'market', 500, 1],
+        [2012, 'market', 300, 1],
+
+        [2012,    'R&D',  10, 1],],
+        order: [:year, :category, :spending, :nb_spending])
+    }
+
+    it 'works as group_by + aggregate' do
+      expect(spending_df.group_by_and_aggregate(:year, {spending: :sum})).to eq(
+        spending_df.group_by(:year).aggregate(spending: :sum))
+      expect(spending_df.group_by_and_aggregate([:year, :category], spending: :sum, nb_spending: :size)).to eq(
+        spending_df.group_by([:year, :category]).aggregate(spending: :sum, nb_spending: :size))
+    end
+  end
+
   context '#create_sql' do
     let(:df) { Daru::DataFrame.new({
         a: [1,2,3],

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -4044,7 +4044,7 @@ describe Daru::DataFrame do
       Daru::DataFrame.new({num: [52,12,07,17,01]}, index: cat_idx) }
 
     it 'lambda function on particular column' do
-      expect(df.aggregate(num_100_times: ->(df) { df.num*100 })).to eq(
+      expect(df.aggregate(num_100_times: ->(df) { (df.num*100).first })).to eq(
           Daru::DataFrame.new(num_100_times: [5200, 1200, 700, 1700, 100])
         )
     end


### PR DESCRIPTION
PR for Issue [453](https://github.com/SciRuby/daru/issues/453)

It might be easier to review commit by commit

I think that the main contribution is the method`Daru::DateFrame#group_by_and_aggregate`, here are some benchmarks: (nowhere extensive)

1/ comparaison of groupping + aggregation - on my PR

```
require 'benchmark'

Benchmark.bm(8) do |b|
  b.report("gr + sum") { 1_000.times { spending_df.group_by(:year).sum } }
  b.report("gr + agg") { 1_000.times { spending_df.group_by(:year).aggregate(spending: :sum, nb_spending: :sum) } }
  b.report("gr_agg")   { 1_000.times { spending_df.group_by_and_aggregate(:year, spending: :sum, nb_spending: :sum) } }
end

#                user     system      total        real
# gr + sum   0.680000   0.000000   0.680000 (  0.673169)
# gr + agg   0.870000   0.000000   0.870000 (  0.871802)
# gr_agg     0.370000   0.000000   0.370000 (  0.370445)
```

2/ I end up refactoring the groupping method (will be a bit slower)

```
## test using `10_000.times { spending_df.group_by(:year).sum }` on first and last commit
#               user     system      total        real
# before    6.270000   0.000000   6.270000 (  6.302841)
# after     6.620000   0.000000   6.620000 (  6.620660)
```

=========================

Please, let me know if there is anything I can improve.
