### PR TITLE
move annoying gem install msgs to postinstall msg

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -45,7 +45,11 @@ statsample family.
 
 Read the README for interesting use cases and examples.
 
+Install the spreadsheet gem version ~>1.1.1 for using spreadsheet functions.
+Install the mechanize gem version ~>2.7.5 for using mechanize functions.
+
 Cheers!
+
 *************************************************************************
 EOF
 

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -86,15 +86,17 @@ module Daru
   create_has_library :gruff
 end
 
+# rubocop:disable Lint/HandleExceptions
 {'spreadsheet' => '~>1.1.1', 'mechanize' => '~>2.7.5'}.each do |name, version|
   begin
     gem name, version
     require name
   rescue LoadError
-    Daru.error "\nInstall the #{name} gem version #{version} for using"\
-    " #{name} functions."
+    # Daru.error "\nInstall the #{name} gem version #{version} for using"\
+    # " #{name} functions."
   end
 end
+# rubocop:enable Lint/HandleExceptions
 
 autoload :CSV, 'csv'
 require 'matrix'


### PR DESCRIPTION
See #404

Messages about optional gems should not be shown each time Daru is loaded.

These messages have been added to the post-install message - this way if anyone is interested in these optional gems, they can install them then...




