### PR TITLE
Optimize aggregation

### DIFF
--- a/lib/daru/category.rb
+++ b/lib/daru/category.rb
@@ -74,6 +74,13 @@ module Daru
       end
     end
 
+    # this method is overwritten: see Daru::Category#plotting_library=
+    def plot(*args, **options, &b)
+      init_plotting_library
+
+      plot(*args, **options, &b)
+    end
+
     alias_method :rename, :name=
 
     # Returns an enumerator that enumerates on categorical data
@@ -748,6 +755,11 @@ module Daru
 
     private
 
+    # Will lazily load the plotting library being used
+    def init_plotting_library
+      self.plotting_library = Daru.plotting_library
+    end
+
     def validate_categories input_categories
       raise ArgumentError, 'Input categories and speculated categories mismatch' unless
         (categories - input_categories).empty?
@@ -768,9 +780,6 @@ module Daru
       # To link every instance to its category,
       # it stores integer for every instance representing its category
       @array = map_cat_int.values_at(*data)
-
-      # Include plotting functionality
-      self.plotting_library = Daru.plotting_library
     end
 
     def category_from_position position

--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -2,6 +2,7 @@ module Daru
   module Core
     class GroupBy
       class << self
+        # @private
         def get_positions_group_map_on(indexes_with_positions, sort: false)
           group_map = {}
 
@@ -17,6 +18,7 @@ module Daru
           group_map
         end
 
+        # @private
         def get_positions_group_for_aggregation(multi_index, level=-1)
           raise unless multi_index.is_a?(Daru::MultiIndex)
 
@@ -26,16 +28,19 @@ module Daru
           get_positions_group_map_on(new_index.each_with_index)
         end
 
+        # @private
         def get_positions_group_map_for_df(df, group_by_keys, sort: true)
           indexes_with_positions = df[*group_by_keys].to_df.each_row.map(&:to_a).each_with_index
 
           get_positions_group_map_on(indexes_with_positions, sort: sort)
         end
 
+        # @private
         def group_map_from_positions_to_indexes(positions_group_map, index)
           positions_group_map.map { |k, positions| [k, positions.map { |pos| index.at(pos) }] }.to_h
         end
 
+        # @private
         def df_from_group_map(df, group_map, remaining_vectors, from_position: true)
           return nil if group_map == {}
 

--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -350,7 +350,9 @@ module Daru
       #           Ram Hyderabad,Mumbai
       #
       def aggregate(options={})
-        grouped_df.aggregate(options)
+        new_index = Daru::MultiIndex.from_tuples(@groups_by_pos.keys).coerce_index
+
+        @context.aggregate(options) { [@groups_by_pos.values, new_index] }
       end
 
       private

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -10,7 +10,8 @@ module Daru
     include Daru::Maths::Arithmetic::DataFrame
     include Daru::Maths::Statistics::DataFrame
     # TODO: Remove this line but its causing erros due to unkown reason
-    include Daru::Plotting::DataFrame::NyaplotLibrary if Daru.has_nyaplot?
+    Daru.has_nyaplot?
+
     extend Gem::Deprecate
 
     class << self
@@ -359,7 +360,6 @@ module Daru
       set_size
       validate
       update
-      self.plotting_library = Daru.plotting_library
     end
 
     def plotting_library= lib
@@ -375,6 +375,13 @@ module Daru
         raise ArguementError, "Plotting library #{lib} not supported. "\
           'Supported libraries are :nyaplot and :gruff'
       end
+    end
+
+    # this method is overwritten: see Daru::DataFrame#plotting_library=
+    def plot(*args, **options, &b)
+      init_plotting_library
+
+      plot(*args, **options, &b)
     end
 
     # Access row or vector. Specify name of row/vector followed by axis(:row, :vector).
@@ -2381,6 +2388,11 @@ module Daru
     end
 
     private
+
+    # Will lazily load the plotting library being used for this dataframe
+    def init_plotting_library
+      self.plotting_library = Daru.plotting_library
+    end
 
     def headers
       Daru::Index.new(Array(index.name) + @vectors.to_a)

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -347,14 +347,14 @@ module Daru
       @name = opts[:name]
 
       case source
-      when ->(s) { s.empty? }
-        @vectors = Index.coerce vectors
-        @index   = Index.coerce index
-        create_empty_vectors
+      when [], {}
+        create_empty_vectors(vectors, index)
       when Array
         initialize_from_array source, vectors, index, opts
       when Hash
         initialize_from_hash source, vectors, index, opts
+      when ->(s) { s.empty? } # TODO: likely want to remove this case
+        create_empty_vectors(vectors, index)
       end
 
       set_size
@@ -2629,7 +2629,10 @@ module Daru
       set_size
     end
 
-    def create_empty_vectors
+    def create_empty_vectors(vectors, index)
+      @vectors = Index.coerce vectors
+      @index   = Index.coerce index
+
       @data = @vectors.map do |name|
         Daru::Vector.new([], name: coerce_name(name), index: @index)
       end
@@ -2949,7 +2952,6 @@ module Daru
 
     # Raises IndexError when one of the positions is not a valid position
     def validate_positions *positions, size
-      positions = [positions] if positions.is_a? Integer
       positions.each do |pos|
         raise IndexError, "#{pos} is not a valid position." if pos >= size
       end

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -74,7 +74,7 @@ module Daru
     def ==(other)
       return false if self.class != other.class || other.size != @size
 
-      @relation_hash.keys == other.to_a &&
+      @keys == other.to_a &&
         @relation_hash.values == other.relation_hash.values
     end
 
@@ -201,7 +201,7 @@ module Daru
     end
 
     def to_a
-      @relation_hash.keys
+      @keys
     end
 
     def key(value)
@@ -230,16 +230,16 @@ module Daru
     #   #     3  false
     #   #     4  true
     def is_values(*indexes) # rubocop:disable Style/PredicateName
-      bool_array = @relation_hash.keys.map { |r| indexes.include?(r) }
+      bool_array = @keys.map { |r| indexes.include?(r) }
       Daru::Vector.new(bool_array)
     end
 
     def empty?
-      @relation_hash.empty?
+      @size.zero?
     end
 
     def dup
-      Daru::Index.new @relation_hash.keys
+      Daru::Index.new @keys
     end
 
     def add *indexes
@@ -285,11 +285,9 @@ module Daru
     #   di.sort #=> Daru::Index.new [1, 2, 99, 100, 101]
     def sort opts={}
       opts = {ascending: true}.merge(opts)
-      if opts[:ascending]
-        new_index, = @relation_hash.sort.transpose
-      else
-        new_index, = @relation_hash.sort.reverse.transpose
-      end
+
+      new_index = @keys.sort
+      new_index = new_index.reverse unless opts[:ascending]
 
       self.class.new(new_index)
     end

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -340,7 +340,6 @@ module Daru
 
     # Raises IndexError when one of the positions is an invalid position
     def validate_positions *positions
-      positions = [positions] if positions.is_a? Integer
       positions.each do |pos|
         raise IndexError, "#{pos} is not a valid position." if pos >= size || pos < -size
       end

--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -196,12 +196,12 @@ module Daru
     end
 
     def add *indexes
-      Daru::MultiIndex.from_tuples to_a << indexes
+      Daru::MultiIndex.from_tuples(to_a + [indexes])
     end
 
     def reorder(new_order)
       from = to_a
-      self.class.from_tuples(new_order.map { |i| from[i] })
+      MultiIndex.from_tuples(new_order.map { |i| from[i] })
     end
 
     def try_retrieve_from_integer int

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1613,7 +1613,6 @@ module Daru
 
     # Raises IndexError when one of the positions is an invalid position
     def validate_positions *positions
-      positions = [positions] if positions.is_a? Integer
       positions.each do |pos|
         raise IndexError, "#{pos} is not a valid position." if pos >= size
       end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -151,8 +151,6 @@ module Daru
     attr_accessor :labels
     # Store vector data in an array
     attr_reader :data
-    # Ploting library being used for this vector
-    attr_reader :plotting_library
     # TODO: Make private.
     attr_reader :nil_positions, :nan_positions
 
@@ -197,6 +195,13 @@ module Daru
       end
     end
 
+    # attr_reader for :plotting_library
+    def plotting_library
+      init_plotting_library
+
+      @plotting_library
+    end
+
     def plotting_library= lib
       case lib
       when :gruff, :nyaplot
@@ -210,6 +215,13 @@ module Daru
         raise ArguementError, "Plotting library #{lib} not supported. "\
           'Supported libraries are :nyaplot and :gruff'
       end
+    end
+
+    # this method is overwritten: see Daru::Vector#plotting_library=
+    def plot(*args, **options, &b)
+      init_plotting_library
+
+      plot(*args, **options, &b)
     end
 
     # Get one or more elements with specified index or a range.
@@ -1481,6 +1493,11 @@ module Daru
 
     private
 
+    # Will lazily load the plotting library being used for this vector
+    def init_plotting_library
+      self.plotting_library = Daru.plotting_library
+    end
+
     def copy(values)
       # Make sure values is right-justified to the size of the vector
       values.concat([nil] * (size-values.size)) if values.size < size
@@ -1514,8 +1531,6 @@ module Daru
       guard_sizes!
 
       @possibly_changed_type = true
-      # Include plotting functionality
-      self.plotting_library = Daru.plotting_library
     end
 
     def parse_source source, opts

--- a/spec/core/group_by_spec.rb
+++ b/spec/core/group_by_spec.rb
@@ -620,9 +620,14 @@ describe Daru::Core::GroupBy do
       end
 
       it 'works as older methods' do
-        newer_way = spending_df.group_by([:year, :category]).aggregate(spending: :sum, nb_spending: :sum)
         older_way = spending_df.group_by([:year, :category]).sum
+
+        newer_way = spending_df.group_by([:year, :category]).aggregate(spending: :sum, nb_spending: :sum)
         expect(newer_way).to eq(older_way)
+
+        contrived_way = spending_df.group_by([:year, :category]).aggregate(spending: :sum, nb_spending_lambda: ->(df) { df[:nb_spending].sum })
+        contrived_way.rename_vectors(nb_spending_lambda: :nb_spending)
+        expect(contrived_way).to eq(older_way)
       end
 
       context 'can aggregate on MultiIndex' do


### PR DESCRIPTION
Hello,

In the continuation of [#454](https://github.com/SciRuby/daru/pull/454), I have made some improvements likely impacting all the aggregation related code (by making things "lazy").

Bellow are some aggregation benchmarks for different ratios of rows vs number of groups. (Summary: some things are ~10 times faster).

```
def gen_df(n_grs, nrows=3000)
  Daru::DataFrame.new({
    group_nb: (1..nrows).map { (1..n_grs).to_a.sample },
    value:    (1..nrows).map { rand },
  })
end

df_s = gen_df   20 # dataframe with a few groups (each having about 150 elements)
df_m = gen_df 2000
df_l = gen_df 4000 # almost every group has one row: lot of sub-vectors creation

# l for lambda
lsize = ->(sub_df) { sub_df[:value].size }
lsum  = ->(sub_df) { sub_df[:value].sum }

require 'benchmark'


# 1/ Benchmark comparing operation over vector and operation with lambda (over sub-dataframes)
# r is for "reference"
Benchmark.bm(8) do |b|
  b.report("small r")  { 100.times { df_s.group_by(:group_nb).aggregate({group_nb: :size, value: :sum}) } }
  b.report("medium r") { 100.times { df_m.group_by(:group_nb).aggregate({group_nb: :size, value: :sum}) } }
  b.report("large r")  { 100.times { df_l.group_by(:group_nb).aggregate({group_nb: :size, value: :sum}) } }

  b.report("small")    { 100.times { df_s.group_by(:group_nb).aggregate({a: lsize, b: lsum}) } }
  b.report("medium")   { 100.times { df_m.group_by(:group_nb).aggregate({a: lsize, b: lsum}) } }
  b.report("large")    { 100.times { df_l.group_by(:group_nb).aggregate({a: lsize, b: lsum}) } }
end

# 2/ Benchmark to see if we could use aggregation instead of the functions in group_by
# r is for "reference"
Benchmark.bm(8) do |b|
  b.report("small r")  { 300.times { df_s.group_by(:group_nb).sum } }
  b.report("small")    { 300.times { df_s.group_by(:group_nb).aggregate({value: :sum}) } }

  b.report("medium r") { 300.times { df_m.group_by(:group_nb).sum } }
  b.report("medium")   { 300.times { df_m.group_by(:group_nb).aggregate({value: :sum}) } }

  b.report("large r")  { 300.times { df_l.group_by(:group_nb).sum } }
  b.report("large")    { 300.times { df_l.group_by(:group_nb).aggregate({value: :sum}) } }
end


## before
# 1/
#                user     system      total        real
# small r   34.150000   0.040000  34.190000 ( 34.201153)
# medium r  67.450000   0.010000  67.460000 ( 67.408840)
# large r   64.300000   0.000000  64.300000 ( 64.294158)
# small     36.600000   0.090000  36.690000 ( 36.677260)
# medium    94.140000   0.000000  94.140000 ( 94.129418)
# large     95.100000   0.000000  95.100000 ( 95.096091)

# 2/
               user     system      total        real
# small r   19.460000   0.000000  19.460000 ( 19.464180)
# small     38.450000   0.150000  38.600000 ( 38.599517)
# medium r  30.440000   0.000000  30.440000 ( 30.432033)
# medium    84.610000   0.000000  84.610000 ( 84.609521)
# large r   33.190000   0.000000  33.190000 ( 33.188716)
# large     96.660000   0.000000  96.660000 ( 96.658534)


## intermediary stats (at commit "Avoids intermediary dataframe creation in Daru::Core::GroupBy#aggregate")
# 1/
               user     system      total        real
# small r    3.710000   0.000000   3.710000 (  3.710371)
# medium r  12.250000   0.000000  12.250000 ( 12.256285)
# large r   16.440000   0.000000  16.440000 ( 16.435032)
# small      5.280000   0.000000   5.280000 (  5.279285)
# medium    37.520000   0.010000  37.530000 ( 37.522483)
# large     48.070000   0.000000  48.070000 ( 48.067751)

# 2/
               user     system      total        real
# small r   10.630000   0.000000  10.630000 ( 10.625822)
# small      9.980000   0.000000   9.980000 (  9.984697)
# medium r  19.790000   0.000000  19.790000 ( 19.789653)
# medium    31.110000   0.000000  31.110000 ( 31.102751)
# large r   20.050000   0.000000  20.050000 ( 20.049377)
# large     41.930000   0.000000  41.930000 ( 41.924821)


## stats at final commit
# 1/
               user     system      total        real
# small r    2.200000   0.000000   2.200000 (  2.198592)
# medium r   6.540000   0.000000   6.540000 (  6.549165)
# large r    8.020000   0.000000   8.020000 (  8.017494)
# small      2.720000   0.000000   2.720000 (  2.717410)
# medium    13.550000   0.000000  13.550000 ( 13.548042)
# large     14.470000   0.000000  14.470000 ( 14.472992)

# 2/
               user     system      total        real
# small r    6.150000   0.000000   6.150000 (  6.148050)
# small      5.440000   0.000000   5.440000 (  5.433489)
# medium r  12.580000   0.000000  12.580000 ( 12.578441)
# medium    11.770000   0.000000  11.770000 ( 11.766527)
# large r   13.430000   0.000000  13.430000 ( 13.435111)
# large     13.970000   0.010000  13.980000 ( 13.973275)
```

=========================

Please, let me know if there is anything I can improve.