### PR TITLE
Make DataFrame.from_activerecord faster

### DIFF
--- a/benchmarks/db_loading.rb
+++ b/benchmarks/db_loading.rb
@@ -1,0 +1,34 @@
+$:.unshift File.expand_path("../../lib", __FILE__)
+
+require 'benchmark'
+require 'daru'
+require 'sqlite3'
+require 'dbi'
+require 'active_record'
+
+db_name = 'daru_test.sqlite'
+FileUtils.rm(db_name) if File.file?(db_name)
+
+SQLite3::Database.new(db_name).tap do |db|
+  db.execute "create table accounts(id integer, name varchar, age integer, primary key(id))"
+
+  values = 1.upto(100_000).map { |i| %!(#{i},"name_#{i}",#{rand(100)})! }.join(",")
+  db.execute "insert into accounts values #{values}"
+end
+
+ActiveRecord::Base.establish_connection("sqlite3:#{db_name}")
+ActiveRecord::Base.connection
+
+class Account < ActiveRecord::Base; end
+
+Benchmark.bm do |x|
+  x.report("DataFrame.from_sql") do
+    Daru::DataFrame.from_sql(ActiveRecord::Base.connection, "SELECT * FROM accounts")
+  end
+
+  x.report("DataFrame.from_activerecord") do
+    Daru::DataFrame.from_activerecord(Account.all)
+  end
+end
+
+FileUtils.rm(db_name)

--- a/lib/daru/io/io.rb
+++ b/lib/daru/io/io.rb
@@ -34,7 +34,7 @@ module Daru
     end
   end
 
-  module IO # rubocop:disable Metrics/ModuleLength
+  module IO
     class << self
       # Functions for loading/writing Excel files.
 


### PR DESCRIPTION
`Daru::DataFrame.from_activerecord` is slower than `Daru::DataFrame.from_sql`.
It may be coused by calling `DataFrame.add_row` many times to build a dataframe.
This PR changes it with calling `DataFrame.new` once and avoid iterating.

**before**
```
       user     system      total        real
DataFrame.from_sql  0.234906   0.000000   0.234906 (  0.235197)
DataFrame.from_activerecord  1.756443   0.035978   1.792421 (  1.792467)
```

**after**
```
       user     system      total        real
DataFrame.from_sql  0.235613   0.000146   0.235759 (  0.236309)
DataFrame.from_activerecord  0.268185   0.008161   0.276346 (  0.276350)
```

### Consideration

`.from_activerecord` can be faster by using `.from_sql` in it.
But it requires ruby-dbi gem to look up `DBI::DatabaseHandle`, even if don't use `DBI`.

**change**

```diff
--- a/lib/daru/io/io.rb
+++ b/lib/daru/io/io.rb
@@ -137,8 +137,9 @@ module Daru
         fields = relation.klass.column_names if fields.empty?
         fields = fields.map(&:to_sym)
 
-        result = relation.pluck(*fields).transpose
-        Daru::DataFrame.new(result, order: fields).tap(&:update)
+        sql = relation.select(*fields).to_sql
+        conn = relation.klass.connection
+        from_sql(conn, sql)
       end
 
       # Loading data from plain text files
```

**benchmark**
```
       user     system      total        real
DataFrame.from_sql  0.232949   0.000000   0.232949 (  0.233108)
DataFrame.from_activerecord  0.243469   0.000000   0.243469 (  0.243494)
```
