### PR TITLE
Fix reindex vector on argument error

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1489,7 +1489,7 @@ module Daru
     def reindex_vectors new_vectors
       unless new_vectors.is_a?(Daru::Index)
         raise ArgumentError, 'Must pass the new index of type Index or its '\
-          "subclasses, not #{new_index.class}"
+          "subclasses, not #{new_vectors.class}"
       end
 
       cl = Daru::DataFrame.new({}, order: new_vectors, index: @index, name: @name)

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2784,6 +2784,11 @@ describe Daru::DataFrame do
         :a  => [1,2,3,4,5]
       }, order: [:b, 'a', :a]))
     end
+
+    it 'raises ArgumentError if argument was not an index' do
+      df = Daru::DataFrame.new([])
+      expect { df.reindex_vectors([]) }.to raise_error(ArgumentError)
+    end
   end
 
   context "#to_matrix" do


### PR DESCRIPTION
Currently, when one gives non-`Daru::Index` object to `Daru::DataFrame#reindex_vectors` method, exception of `NoMethodError` is raised instead of `ArgumentError`, the intended exception.

Reason is that when `raise`ing the exception, an non-existing variable of `new_index` is referenced.  I think this was caused by simply copying the code from `reindex` method.

This PR fixes this and when non index is given, it properly throws ArgumentError.