### PR TITLE
implements DataFrame#reset_index

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1572,6 +1572,17 @@ module Daru
       end
     end
 
+    def reset_index
+      index_df = index.to_df
+      names = index.name
+      names = [names] unless names.instance_of?(Array)
+      names.each do |name|
+        self[name] = index_df[name]
+      end
+      self.index = index_df.index
+      self
+    end
+
     # Reassign index with a new index of type Daru::Index or any of its subclasses.
     #
     # @param [Daru::Index] idx New index object on which the rows of the dataframe

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1576,10 +1576,12 @@ module Daru
       index_df = index.to_df
       names = index.name
       names = [names] unless names.instance_of?(Array)
+      new_vectors = names + vectors.to_a
+      self.index = index_df.index
       names.each do |name|
         self[name] = index_df[name]
       end
-      self.index = index_df.index
+      self.order = new_vectors
       self
     end
 

--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -294,6 +294,10 @@ module Daru
       self.class.new(new_index)
     end
 
+    def to_df
+      Daru::DataFrame.new(name => to_a)
+    end
+
     private
 
     def guess_index index

--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -9,6 +9,7 @@ module Daru
     end
 
     attr_reader :labels
+    attr_reader :name
 
     def levels
       @levels.map(&:keys)
@@ -364,6 +365,10 @@ module Daru
         left = cur.zip(prev).drop_while { |c, p| c == p }
         [nil] * (cur.size - left.size) + left.map(&:first)
       }
+    end
+
+    def to_df
+      Daru::DataFrame.new(@name.zip(to_a.transpose).to_h)
     end
   end
 end

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -3673,6 +3673,41 @@ describe Daru::DataFrame do
     end
   end
 
+  context '#reset_index' do
+    context 'when Index' do
+      subject do
+        Daru::DataFrame.new(
+          {'vals' => [1,2,3,4,5]},
+          index: Daru::Index.new(%w[a b c d e], name: 'indices')
+        ).reset_index
+      end
+
+      it { is_expected.to eq Daru::DataFrame.new(
+        'indices' => %w[a b c d e],
+        'vals' => [1,2,3,4,5]
+      )}
+    end
+
+    context 'when MultiIndex' do
+      subject do
+        mi = Daru::MultiIndex.from_tuples([
+          [0, 'a'], [0, 'b'], [1, 'a'], [1, 'b']
+        ])
+        mi.name = %w[nums alphas]
+        Daru::DataFrame.new(
+          {'vals' => [1,2,3,4]},
+          index: mi
+        ).reset_index
+      end
+
+      it { is_expected.to eq Daru::DataFrame.new(
+        'nums' => [0,0,1,1],
+        'alphas' => %w[a b a b],
+        'vals' => [1,2,3,4]
+      )}
+    end
+  end
+
   context "#set_index" do
     before(:each) do
       @df = Daru::DataFrame.new({

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -388,4 +388,17 @@ describe Daru::Index do
     end
 
   end
+
+  context '#to_df' do
+    let(:idx) do
+      Daru::Index.new(['speaker', 'mic', 'guitar', 'amp'],
+                      name: 'instruments')
+    end
+    subject { idx.to_df }
+
+    it { is_expected.to eq Daru::DataFrame.new(
+           'instruments' => ['speaker', 'mic', 'guitar', 'amp']
+         )
+    }
+  end
 end

--- a/spec/index/multi_index_spec.rb
+++ b/spec/index/multi_index_spec.rb
@@ -659,4 +659,22 @@ describe Daru::MultiIndex do
       it { expect(idx.valid? :a, :three).to eq false }
     end
   end
+
+  context '#to_df' do
+    let(:idx) do
+      described_class.from_tuples([
+        %w[a one bar],
+        %w[a two bar],
+        %w[b two baz],
+        %w[b one foo]
+      ]).tap { |idx| idx.name = %w[col1 col2 col3] }
+    end
+
+    subject { idx.to_df }
+    it { is_expected.to eq Daru::DataFrame.new(
+           'col1' => %w[a a b b],
+           'col2' => %w[one two two one],
+           'col3' => %w[bar bar baz foo]
+    )}
+  end
 end


### PR DESCRIPTION
reset_index will change index into columns.
Refer: https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.reset_index.html

To implement this method, `Index#to_df` and `MultiIndex#to_df` was also defined.  Since pandas also have such method, I think we can get benefits by implementing such method.
refer: https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.MultiIndex.to_frame.html#pandas.MultiIndex.to_frame