### PR TITLE
Adds option to display all data on inspect

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2229,7 +2229,11 @@ module Daru
     end
 
     # Pretty print in a nice table format for the command line (irb/pry/iruby)
-    def inspect spacing=10, threshold=15
+    #
+    # @option [Boolean] all: when true, will remove thresholding (and will override any value set for threshold)
+    def inspect spacing=10, threshold=15, all: false
+      threshold = :all if all
+
       name_part = @name ? ": #{@name} " : ''
 
       "#<#{self.class}#{name_part}(#{nrows}x#{ncols})>\n" +

--- a/lib/daru/formatters/table.rb
+++ b/lib/daru/formatters/table.rb
@@ -26,8 +26,14 @@ module Daru
 
       private
 
+      # you can skip thresholding by setting threshold to :all
       def build_rows threshold # rubocop:disable Metrics/AbcSize
-        @row_headers.first(threshold).zip(@data).map do |(r, datarow)|
+        has_threshold = (threshold != :all)
+
+        selected_row_headers = @row_headers
+        selected_row_headers = selected_row_headers.first(threshold) if has_threshold
+
+        selected_row_headers.zip(@data).map do |(r, datarow)|
           [*[r].flatten.map(&:to_s), *(datarow || []).map(&method(:pretty_to_s))]
         end.tap do |rows|
           unless @headers.empty?
@@ -35,7 +41,7 @@ module Daru
             rows.unshift [''] * spaces_to_add + @headers.map(&:to_s)
           end
 
-          rows << ['...'] * rows.first.count if @row_headers.count > threshold
+          rows << ['...'] * rows.first.count if has_threshold && @row_headers.count > threshold
         end
       end
 

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1078,7 +1078,11 @@ module Daru
     end
 
     # Over rides original inspect for pretty printing in irb
-    def inspect spacing=20, threshold=15
+    #
+    # @option [Boolean] all: when true, will remove thresholding (and will override any value set for threshold)
+    def inspect spacing=20, threshold=15, all: false
+      threshold = :all if all
+
       row_headers = index.is_a?(MultiIndex) ? index.sparse_tuples : index.to_a
 
       "#<#{self.class}(#{size})#{':category' if category?}>\n" +

--- a/spec/formatters/table_formatter_spec.rb
+++ b/spec/formatters/table_formatter_spec.rb
@@ -104,6 +104,16 @@ describe Daru::Formatters::Table do
         | row3    7    8    9
       }.unindent}
     end
+
+    context 'when set to :all' do
+      let(:threshold) { :all }
+      it { is_expected.to eq %Q{
+        |      col1 col2 col3
+        | row1    1    2    3
+        | row2    4    5    6
+        | row3    7    8    9
+      }.unindent}
+    end
   end
 
   context 'no row and column headers' do


### PR DESCRIPTION
Hello,

By default, using inspect on dataframe/vector/other will not display the whole data.

I have added an option that I think can be useful.


```
vect = Daru::Vector.new((1..16))

# before
vect
# => #<Daru::Vector(16)>
#    0   1
#    1   2
#    2   3
#    3   4
#    4   5
#    5   6
#    6   7
#    7   8
#    8   9
#    9  10
#   10  11
#   11  12
#   12  13
#   13  14
#   14  15
#  ... ...


# after
puts vect.inspect(all: true);nil
# #<Daru::Vector(16)>
#    0   1
#    1   2
#    2   3
#    3   4
#    4   5
#    5   6
#    6   7
#    7   8
#    8   9
#    9  10
#   10  11
#   11  12
#   12  13
#   13  14
#   14  15
#   15  16
# => nil
```

Let me know if there is an better way, or any improvement I can make to this PR.