### PR TITLE
Index#dup should copy reference to name too

### DIFF
--- a/lib/daru/index/index.rb
+++ b/lib/daru/index/index.rb
@@ -239,7 +239,7 @@ module Daru
     end
 
     def dup
-      Daru::Index.new @keys
+      Daru::Index.new @keys, name: @name
     end
 
     def add *indexes

--- a/spec/index/index_spec.rb
+++ b/spec/index/index_spec.rb
@@ -401,4 +401,17 @@ describe Daru::Index do
          )
     }
   end
+
+  context "#dup" do
+    let(:idx) do
+      Daru::Index.new(['speaker', 'mic', 'guitar', 'amp'],
+                      name: 'instruments')
+    end
+    subject { idx.dup }
+
+    it { is_expected.to eq idx }
+    it 'have same names' do
+      expect(subject.name).to eq idx.name
+    end
+  end
 end


### PR DESCRIPTION
Currently, if `idx.instance_of?(Daru::Index)`, then following statement does not hold:

```ruby
idx.dup.name == idx.name
# => returns false!!
```

This is because name is not copied on `Daru::Index#dup`, which I think is not the expected behavior at least to the library user.


So, this PR fixes it.