### PR TITLE
Should support bundler version 2.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ script:
   - bundle exec yard-junk
 
 install:
-  - gem install bundler
+  - if [ $TRAVIS_RUBY_VERSION == '2.2' ] || [ $TRAVIS_RUBY_VERSION == '2.1' ] || [ $TRAVIS_RUBY_VERSION == '2.0' ];
+      then gem install bundler -v '~> 1.6';
+      else gem install bundler;
+      fi
   - gem install rainbow -v '2.2.1'
   - bundle install
 

--- a/daru.gemspec
+++ b/daru.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'packable', '~> 1.3.9'
 
   spec.add_development_dependency 'spreadsheet', '~> 1.1.1'
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '>= 1.10'
   spec.add_development_dependency 'rake', '~>10.5'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
I got an error while using bundler 2.0 : 

```
 ➜  bundle install
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.10)

  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.10)' in any of the relevant sources:
  the local ruby installation

```