### PR TITLE
Refactor apply_method in GroupBy

### DIFF
--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -2,6 +2,8 @@ module Daru
   module Core
     class GroupBy
       class << self
+        extend Gem::Deprecate
+
         # @private
         def group_by_index_to_positions(indexes_with_positions, sort: false)
           index_to_positions = {}
@@ -17,6 +19,8 @@ module Daru
 
           index_to_positions
         end
+        alias get_positions_group_map_on group_by_index_to_positions
+        deprecate :get_positions_group_map_on, :group_by_index_to_positions, 2019, 10
 
         # @private
         def get_positions_group_for_aggregation(multi_index, level=-1)

--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -369,21 +369,15 @@ module Daru
         Daru::DataFrame.rows(rows, order: @context.vectors, index: indexes)
       end
 
+      def select_numeric_non_group_vectors
+        @non_group_vectors.select { |ngvec| @context[ngvec].type == :numeric }
+      end
+
       def apply_method method_type, method
-        order = @non_group_vectors.select do |ngvec|
-          method_type == :numeric && @context[ngvec].type == :numeric
-        end
+        raise 'To implement' if method_type != :numeric
+        aggregation_options = select_numeric_non_group_vectors.map { |k| [k, method] }.to_h
 
-        rows = groups_by_idx.map do |_group, indexes|
-          order.map do |ngvector|
-            slice = @context[ngvector][*indexes]
-            slice.is_a?(Daru::Vector) ? slice.send(method) : slice
-          end
-        end
-
-        index = get_grouped_index
-        order = Daru::Index.new(order)
-        Daru::DataFrame.new(rows.transpose, index: index, order: order)
+        aggregate(aggregation_options)
       end
 
       def get_grouped_index(index_tuples=nil)


### PR DESCRIPTION
Hello!

This is a (minor) PR in the continuation of [464](https://github.com/SciRuby/daru/pull/464), best reviewed commit by commit.

The speed is mostly unchanged (see benchmark 2/ in the section "stats at final commit" of the previous PR).

It does fix a minor bug:

```
gr   = Daru::Vector.new([:a,:a,:a, :b])
vals = Daru::Vector.new([1,1,1,753])

Daru::DataFrame.new({gr: gr, vals: vals}).group_by(:gr).std

## Before
# => #<Daru::DataFrame(2x1)>
#       vals
#     a  0.0
#     b  753

## After
# => #<Daru::DataFrame(2x1)>
#       vals
#     a  0.0
#     b  NaN


# it was wrong because the (unbiased) std is not defined for a vector of size 1:
Daru::Vector.new([753]).std
# => NaN
```

The error was the line `slice.is_a?(Daru::Vector) ? slice.send(method) : slice` (ok for all the other cases, but not for std).

I also have renamed a method and added some deprecation code.


Please, let me know if there is anything I can improve.