### PR TITLE
fix table style

### DIFF
--- a/lib/daru/iruby/templates/dataframe.html.erb
+++ b/lib/daru/iruby/templates/dataframe.html.erb
@@ -1,5 +1,5 @@
 <b> Daru::DataFrame<%= name ? ": #{name} " : ''%>(<%=nrows%>x<%=ncols%>) </b>
-<table>
+<table border="1" class="dataframe">
   <%= table_thead %>
   <%= table_tbody %>
 </table>


### PR DESCRIPTION
 # Improve the appearance of the table. 

I am [running IRuby & Daru on Google Colab](https://dev.to/kojix2/ruby-kernel-in-google-colaboratory-32ni). Google Colab officially supports Python. But Ruby works.

### The `dataframe` style is not adapted to the table.
```html
<table></table>
```
![image](https://user-images.githubusercontent.com/5798442/52929028-e9577280-3385-11e9-9284-5448b85a2c02.png)

### After adding the dataframe class to the table tag, Daru::DataFrame looks better.
This is as same as Pandas. 
```html
<table border="1" class="dataframe"></table>
```
![image](https://user-images.githubusercontent.com/5798442/52929285-240dda80-3387-11e9-82b9-8f9291717a98.png)

I hope the Google Colab team officially support the IRuby kernel someday. Therefore, I think that such minor change in appearance is more important than expected.