### PR TITLE
Printing to terminal headers spacing auto-adjust

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2231,9 +2231,9 @@ module Daru
     # Pretty print in a nice table format for the command line (irb/pry/iruby)
     def inspect spacing=10, threshold=15
       name_part = @name ? ": #{@name} " : ''
-      spacing = [headers.to_a.map { |s| s.length }.max, spacing].max
+      spacing = [headers.to_a.map(&:length).max, spacing].max
 
-      "#<#{self.class}#{name_part}(#{nrows}x#{ncols})>#{$/}" +
+      "#<#{self.class}#{name_part}(#{nrows}x#{ncols})>#{$INPUT_RECORD_SEPARATOR}" +
         Formatters::Table.format(
           each_row.lazy,
           row_headers: row_headers,

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2231,8 +2231,9 @@ module Daru
     # Pretty print in a nice table format for the command line (irb/pry/iruby)
     def inspect spacing=10, threshold=15
       name_part = @name ? ": #{@name} " : ''
+      spacing = [headers.to_a.map { |s| s.length }.max, spacing].max
 
-      "#<#{self.class}#{name_part}(#{nrows}x#{ncols})>\n" +
+      "#<#{self.class}#{name_part}(#{nrows}x#{ncols})>#{$/}" +
         Formatters::Table.format(
           each_row.lazy,
           row_headers: row_headers,


### PR DESCRIPTION
Defining spacing to be the maximal between requested and the maximal
header length.
Issue: #509 