### PR TITLE
Second, Minute, Hour and Day offsets now express equality

### DIFF
--- a/lib/daru/date_time/offsets.rb
+++ b/lib/daru/date_time/offsets.rb
@@ -111,6 +111,14 @@ module Daru
       def - date_time
         date_time - @n*multiplier
       end
+
+      def ==(other_obj)
+        other_obj.is_a?(Tick) && period == other_obj.period
+      end
+
+      def period
+        @n * multiplier
+      end
     end
 
     # Create a seconds offset

--- a/spec/date_time/offsets_spec.rb
+++ b/spec/date_time/offsets_spec.rb
@@ -140,6 +140,20 @@ describe Offsets do
           DateTime.new(2012,2,3,12,4,18))
       end
     end
+
+    context "#==" do
+      it 'equals the same offset' do
+        expect(Offsets::Second.new(5)).to eq(Offsets::Second.new(5))
+      end
+
+      it 'does equal a different offset' do
+        expect(Offsets::Second.new(5)).to_not eq(Offsets::Second.new(4))
+      end
+
+      it 'equals offets with the same period' do
+        expect(Offsets::Second.new(60)).to eq(Offsets::Minute.new())
+      end
+    end
   end
 
   describe Minute do


### PR DESCRIPTION
Fixes #526 

I haven't implemented equality in all offsets because Week, Month and Year offsets do not implement the `multiplier` method.

