### PR TITLE
Infer offsets that are a natural number multiple of seconds

### DIFF
--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -93,11 +93,12 @@ module Daru
       def infer_offset data
         diffs = data.each_cons(2).map { |d1, d2| d2 - d1 }
 
-        if diffs.uniq.count == 1
-          TIME_INTERVALS[diffs.first].new
-        else
-          nil
-        end
+        return nil unless diffs.uniq.count == 1
+
+        return TIME_INTERVALS[diffs.first].new if TIME_INTERVALS.include?(diffs.first)
+
+        number_of_seconds = diffs.first / Daru::Offsets::Second.new.multiplier
+        Daru::Offsets::Second.new(number_of_seconds.numerator) if number_of_seconds.denominator == 1
       end
 
       def find_index_of_date data, date_time

--- a/spec/date_time/date_time_index_helper_spec.rb
+++ b/spec/date_time/date_time_index_helper_spec.rb
@@ -1,0 +1,72 @@
+include Daru
+
+describe Daru::DateTimeIndexHelper do
+
+
+  describe '.infer_offset' do
+    subject(:offset) { Daru::DateTimeIndexHelper.infer_offset(data) }
+
+    context 'when the dataset does not have a regular offset' do
+      let(:data) do
+        [
+          DateTime.new(2020, 1, 1, 00, 00, 00),
+          DateTime.new(2020, 1, 1, 00, 01, 00),
+          DateTime.new(2020, 1, 1, 00, 05, 00),
+        ]
+      end
+
+      it 'returns nil' do
+        expect(offset).to be_nil
+      end
+    end
+
+    context 'when the dataset matches a defined offset' do
+      let(:data) do
+        [
+          DateTime.new(2020, 1, 1, 00, 00, 00),
+          DateTime.new(2020, 1, 1, 00, 01, 00),
+          DateTime.new(2020, 1, 1, 00, 02, 00),
+        ]
+      end
+
+      it 'returns the matched offset' do
+        expect(offset).to be_an_instance_of(Daru::Offsets::Minute)
+      end
+    end
+
+    context 'when the offset is a multiple of seconds' do
+      let(:data) do
+        [
+          DateTime.new(2020, 1, 1, 00, 00, 00),
+          DateTime.new(2020, 1, 1, 00, 00, 03),
+          DateTime.new(2020, 1, 1, 00, 00, 06),
+        ]
+      end
+
+      let(:expected_offset) { Daru::Offsets::Second.new(3) }
+
+      it 'returns a Second offset' do
+        expect(offset).to be_an_instance_of(Daru::Offsets::Second)
+      end
+
+      it 'has the correct multiplier' do
+        expect(offset.freq_string).to eql(expected_offset.freq_string)
+      end
+    end
+
+    context 'when the offset is less than a second' do
+      let(:data) do
+        [
+          DateTime.new(2020, 1, 1, 00, 00, 00) + 0.00001,
+          DateTime.new(2020, 1, 1, 00, 00, 00) + 0.00002,
+          DateTime.new(2020, 1, 1, 00, 00, 00) + 0.00003,
+        ]
+      end
+
+      it 'returns nil' do
+        expect(offset).to be_nil
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes #527 

I'd prefer to express all inferred offsets as a multiple of seconds, however I've attempted to retain the existing behaviour which could return an instance of `Daru::Offsets::Day`, `Daru::Offsets::Hour`, `Daru::Offsets::Minute` or `Daru::Offsets::Second`.

Where the offset is less than 1 second I'm still returning `nil` which could be contentious.  So I'm happy to change that but it would means that the method `#freq_string` can return results like `1/100000S`

