### PR TITLE
Add bang-version of Daru::DataFrame#rename_vectors for chaining calls

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['sameer.deshmukh93@gmail.com']
   spec.summary       = %q{Data Analysis in RUby}
   spec.description   = Daru::DESCRIPTION
-  spec.homepage      = "http://github.com/v0dro/daru"
+  spec.homepage      = "http://github.com/SciRuby/daru"
   spec.license       = 'BSD-2'
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1696,6 +1696,24 @@ module Daru
       self.vectors = Daru::Index.new new_names
     end
 
+    # Renames the vectors and returns itself
+    #
+    # == Arguments
+    #
+    # * name_map - A hash where the keys are the exising vector names and
+    #              the values are the new names.  If a vector is renamed
+    #              to a vector name that is already in use, the existing
+    #              one is overwritten.
+    #
+    # == Usage
+    #
+    #   df = Daru::DataFrame.new({ a: [1,2,3,4], b: [:a,:b,:c,:d], c: [11,22,33,44] })
+    #   df.rename_vectors! :a => :alpha, :c => :gamma # df
+    def rename_vectors! name_map
+      rename_vectors(name_map)
+      self
+    end
+
     # Return the indexes of all the numeric vectors. Will include vectors with nils
     # alongwith numbers.
     def numeric_vectors

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2720,6 +2720,26 @@ describe Daru::DataFrame do
     end
   end
 
+  context "#rename_vectors!" do
+    before do
+      @df = Daru::DataFrame.new({
+        a: [1,2,3,4,5],
+        b: [11,22,33,44,55],
+        c: %w(a b c d e)
+      })
+    end
+
+    it "returns self as modified dataframe" do
+      expect(@df.rename_vectors!(:a => :alpha)).to eq(@df)
+    end
+
+    it "re-uses rename_vectors method" do
+      name_map = { :a => :alpha, :c => :gamma }
+      expect(@df).to receive(:rename_vectors).with(name_map)
+      @df.rename_vectors! name_map
+    end
+  end
+
   context "#rename_vectors" do
     before do
       @df = Daru::DataFrame.new({
@@ -2727,6 +2747,10 @@ describe Daru::DataFrame do
         b: [11,22,33,44,55],
         c: %w(a b c d e)
       })
+    end
+
+    it "returns Daru::Index" do
+      expect(@df.rename_vectors(:a => :alpha)).to be_kind_of(Daru::Index)
     end
 
     it "renames vectors using a hash map" do


### PR DESCRIPTION
Oftentimes when working with Daru's dataframes I encounter the problem that I want to do some "default" actions within a single chain of method calls, i.e. renaming the dataframe columns. Unfortunately, as `Daru::DataFrame` returns the new index set, one cannot chain the method calls, so the invocation of  `rename_vectors` always needs a separate expression: 

```Ruby
df = SomeCollection.to_df
df.rename_vectors(a: :alpha)
df.some_other_action!
df.another_operation
df
```

For convenience and compactness, it would help me to to such things in a more functional chaining manner like

```Ruby
df = 
  SomeCollection
    .to_df
    .rename_vectors!(a: :alpha)
    .some_other_action!
    .and_another_operation!
    .rename_vectors!(b: :beta)
```

Fortunately it's quite easy to achieve. As stated in the latter snippet, I added a sibling method for `rename_vectors`, namely, `rename_vectors!` that differs from `rename_vectors` by its return value. The new method returns the dataframe itself so that one can profit from chaining if one wants to.  

Actually, in my work I never encountered the situation that the _current_ return value of `Daru::DataFrame#rename_vectors`, the index set, is really of interest, so I first thought of
just modifying the `rename_vectors` method itself. But even this would be still my favourite version I do not know if this would break other people's code - that's whyI'm not certain if this would be a good idea. What do you think?  