### PR TITLE
Support running specs without gsl or nmatrix installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     true
 
 env:
-  - DARU_TEST_NMATRIX=1 DARU_TEST_GSL=1
+  - DARU_TEST_NMATRIX=1 DARU_TEST_GSL=1 DARU_TEST_RSERVE=1
 
 script:
   - bundle add yard-junk

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2415,7 +2415,7 @@ describe Daru::DataFrame do
   end
 
   context "#recast" do
-    it "recasts underlying vectors" do
+    it "recasts underlying vectors", :nmatrix do
       @data_frame.recast a: :nmatrix, c: :nmatrix
 
       expect(@data_frame.a.dtype).to eq(:nmatrix)
@@ -2875,7 +2875,7 @@ describe Daru::DataFrame do
     end
   end
 
-  context "#to_nmatrix" do
+  context "#to_nmatrix", :nmatrix do
     before do
       @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
         c: [11,22,33,44,55], d: [5,4,nil,2,1], e: ['this', 'has', 'string','data','too']},
@@ -3274,7 +3274,7 @@ describe Daru::DataFrame do
     end
   end
 
-  context "#to_gsl" do
+  context "#to_gsl", :gsl do
     it "converts to GSL::Matrix" do
       rows = [[1,2,3,4,5],[11,12,13,14,15],[11,22,33,44,55]].transpose
       mat = GSL::Matrix.alloc *rows

--- a/spec/extensions/rserve_spec.rb
+++ b/spec/extensions/rserve_spec.rb
@@ -2,7 +2,7 @@ begin
   require "rserve"
   require 'daru/extensions/rserve'
 
-  describe "Daru rserve extension" do
+  describe "Daru rserve extension", :rserve do
     before do
       @r = Rserve::Connection.new
     end

--- a/spec/io/io_spec.rb
+++ b/spec/io/io_spec.rb
@@ -525,7 +525,7 @@ describe Daru::IO do
 
     context "#save" do
       ALL_DTYPES.each do |dtype|
-        it "saves to a file and returns the same Vector of type #{dtype}" do
+        it "saves to a file and returns the same Vector of type #{dtype}", dtype do
           vector = Daru::Vector.new(
               [5, 5, 5, 5, 5, 6, 6, 7, 8, 9, 10, 1, 2, 3, 4, 11, -99, -99],
               dtype: dtype)

--- a/spec/maths/statistics/vector_spec.rb
+++ b/spec/maths/statistics/vector_spec.rb
@@ -1,6 +1,6 @@
 describe Daru::Vector do
   [:array, :gsl].each do |dtype| #nmatrix still unstable
-    describe dtype do
+    describe dtype.to_s, dtype do
       before do
         @dv = Daru::Vector.new [323, 11, 555, 666, 234, 21, 666, 343, 1, 2], dtype: dtype
         @dv_with_nils = Daru::Vector.new [323, 11, 555, nil, 666, 234, 21, 666, 343, nil, 1, 2]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,7 @@ end
 RSpec.configure do |c|
   c.filter_run_excluding(:gsl) unless Daru.has_gsl?
   c.filter_run_excluding(:nmatrix) unless Daru.has_nmatrix?
+  c.filter_run_excluding(:rserve) unless ENV['DARU_TEST_RSERVE']
 end
 
 RSpec::Matchers.define :be_all_within do |delta|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,11 @@ def expect_correct_df_in_delta df1, df2, delta
   end
 end
 
+RSpec.configure do |c|
+  c.filter_run_excluding(:gsl) unless Daru.has_gsl?
+  c.filter_run_excluding(:nmatrix) unless Daru.has_nmatrix?
+end
+
 RSpec::Matchers.define :be_all_within do |delta|
   match do |actual|
     expect(@expected).to_not be_nil

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper.rb'
 
 describe Daru::Vector do
   ALL_DTYPES.each do |dtype|
-    describe dtype.to_s do
+    describe dtype.to_s, dtype do
       before do
         @common_all_dtypes =  Daru::Vector.new(
           [5, 5, 5, 5, 5, 6, 6, 7, 8, 9, 10, 1, 2, 3, 4, 11, -99, -99],
@@ -84,7 +84,7 @@ describe Daru::Vector do
           expect(dv.index.to_a).to eq(['a', 'b', :r, 0])
         end
 
-        it "initializes array with nils with dtype NMatrix" do
+        it "initializes array with nils with dtype NMatrix", :nmatrix do
           dv = Daru::Vector.new [2, nil], dtype: :nmatrix
           expect(dv.to_a).to eq([2, nil])
           expect(dv.index.to_a).to eq([0, 1])
@@ -1064,7 +1064,7 @@ describe Daru::Vector do
 
       context "#cast" do
         ALL_DTYPES.each do |new_dtype|
-          it "casts from #{dtype} to #{new_dtype}" do
+          it "casts from #{dtype} to #{new_dtype}", new_dtype do
             v = Daru::Vector.new [1,2,3,4], dtype: dtype
             v.cast(dtype: new_dtype)
             expect(v.dtype).to eq(new_dtype)
@@ -1360,18 +1360,13 @@ describe Daru::Vector do
           expect(a.dtype).to eq(:array)
         end
 
-        it "maps and returns a vector of dtype gsl" do
-          a = @common_all_dtypes.recode(:gsl) { |v| v == -99 ? 1 : 0 }
-          exp = Daru::Vector.new [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], dtype: :gsl
-          expect(a).to eq(exp)
-          expect(a.dtype).to eq(:gsl)
-        end
-
-        it "maps and returns a vector of dtype nmatrix" do
-          a = @common_all_dtypes.recode(:nmatrix) { |v| v == -99 ? 1 : 0 }
-          exp = Daru::Vector.new [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], dtype: :nmatrix
-          expect(a).to eq(exp)
-          expect(a.dtype).to eq(:nmatrix)
+        ALL_DTYPES.each do |dtype|
+          it "maps and returns a vector of dtype #{dtype}", dtype do
+            a = @common_all_dtypes.recode(dtype) { |v| v == -99 ? 1 : 0 }
+            exp = Daru::Vector.new [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], dtype: dtype
+            expect(a).to eq(exp)
+            expect(a.dtype).to eq(exp.dtype)
+          end
         end
       end
 
@@ -1389,18 +1384,13 @@ describe Daru::Vector do
           expect(@vector.dtype).to eq(dtype)
         end
 
-        it "destructively maps and returns a vector of dtype gsl" do
-          @vector.recode!(:gsl) { |v| v == -99 ? 1 : 0 }
-          exp = Daru::Vector.new [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], dtype: :gsl
-          expect(@vector).to eq(exp)
-          expect(@vector.dtype).to eq(exp.dtype)
-        end
-
-        it "destructively maps and returns a vector of dtype nmatrix" do
-          @vector.recode!(:nmatrix) { |v| v == -99 ? 1 : 0 }
-          exp = Daru::Vector.new [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], dtype: :nmatrix
-          expect(@vector).to eq(exp)
-          expect(@vector.dtype).to eq(exp.dtype)
+        ALL_DTYPES.each do |dtype|
+          it "destructively maps and returns a vector of dtype #{dtype}", dtype do
+            @vector.recode!(dtype) { |v| v == -99 ? 1 : 0 }
+            exp = Daru::Vector.new [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], dtype: dtype
+            expect(@vector).to eq(exp)
+            expect(@vector.dtype).to eq(exp.dtype)
+          end
         end
       end
 
@@ -1593,7 +1583,7 @@ describe Daru::Vector do
       its(:'index.to_a') { is_expected.to eq [] }
     end
 
-    context 'works for gsl' do
+    context 'works for gsl', :gsl do 
       let(:dv) { Daru::Vector.new [1, 2, 3, Float::NAN], dtype: :gsl,
         index: 11..14 }
       subject { dv.reject_values Float::NAN }
@@ -1857,7 +1847,7 @@ describe Daru::Vector do
       expect(@multi.type).to eq(:object)
     end
 
-    it "tells NMatrix data type in case of NMatrix wrapper" do
+    it "tells NMatrix data type in case of NMatrix wrapper", :nmatrix do
       nm = Daru::Vector.new([1,2,3,4,5], dtype: :nmatrix)
       expect(nm.type).to eq(:int32)
     end
@@ -1908,7 +1898,7 @@ describe Daru::Vector do
     end
   end
 
-  context '#to_nmatrix' do
+  context '#to_nmatrix', :nmatrix do
     let(:dv) { Daru::Vector.new [1, 2, 3, 4, 5] }
 
     context 'horizontal axis' do
@@ -1945,7 +1935,7 @@ describe Daru::Vector do
     end
   end
 
-  context "#to_gsl" do
+  context "#to_gsl", :gsl do
     it "returns a GSL::Vector of non-nil data" do
       vector = Daru::Vector.new [1,2,3,4,nil,6,nil]
       expect(vector.to_gsl).to eq(GSL::Vector.alloc(1,2,3,4,6))


### PR DESCRIPTION
Specs don't run cleanly without GSL and NMatrix gems installed. This fixes that by using simple rspec typing

Also excludes RServe specs unless ENV variable is set.