### PR TITLE
MultiIndexed Vectors and DataFrames should return Daru::Index when only one level remains

### DIFF
--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -290,7 +290,12 @@ module Daru
     end
 
     def drop_left_level by=1
-      MultiIndex.from_arrays to_a.transpose[by..-1]
+      arrays = to_a.transpose[by..-1]
+      if arrays.length == 1
+        Index.new(arrays[0])
+      else
+        MultiIndex.from_arrays to_a.transpose[by..-1]
+      end
     end
 
     def | other

--- a/spec/category_spec.rb
+++ b/spec/category_spec.rb
@@ -689,15 +689,13 @@ describe Daru::Vector, "categorical" do
       end
 
       it "returns sub vector when passed first and second layer of tuple" do
-        mi = Daru::MultiIndex.from_tuples([
-          [:foo],
-          [:bar]])
+        mi = Daru::Index.new([:foo,:bar])
         expect(@vector[:c,:two]).to eq(Daru::Vector.new([10,11], index: mi,
           name: :sub_sub_vector, type: :category))
       end
 
       it "returns sub vector not a single element when passed the partial tuple" do
-        mi = Daru::MultiIndex.from_tuples([[:foo]])
+        mi = Daru::Index.new([:foo])
         expect(@vector[:d, :one]).to eq(Daru::Vector.new([12], index: mi,
           name: :sub_sub_vector, type: :category))
       end

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -507,9 +507,16 @@ describe Daru::DataFrame do
         sub_order = Daru::MultiIndex.from_tuples([
           [:one, :bar],
           [:two, :baz]
-          ])
+        ])
         expect(@df_mi[:a]).to eq(Daru::DataFrame.new([
           @vector_arry1,
+          @vector_arry2
+        ], index: @multi_index, order: sub_order))
+      end
+
+      it "returns DataFrame with simple index when specified first and second layer of MultiIndex" do
+        sub_order = Daru::Index.new([:baz])
+        expect(@df_mi[:a][:two]).to eq(Daru::DataFrame.new([
           @vector_arry2
         ], index: @multi_index, order: sub_order))
       end
@@ -1525,10 +1532,7 @@ describe Daru::DataFrame do
       end
 
       it "returns DataFrame when specifying first and second layer of MultiIndex" do
-        sub_index = Daru::MultiIndex.from_tuples([
-          [:bar],
-          [:baz]
-        ])
+        sub_index = Daru::Index.new([:bar,:baz])
         expect(@df_mi.row[:c,:one]).to eq(Daru::DataFrame.new([
           [11,12],
           [1,2],

--- a/spec/index/multi_index_spec.rb
+++ b/spec/index/multi_index_spec.rb
@@ -453,6 +453,16 @@ describe Daru::MultiIndex do
           ])
       )
     end
+
+    it "returns a Daru::Index if a single level remains" do
+      expect(
+        Daru::MultiIndex.from_tuples([
+          [:c,:one,:bar],
+          [:c,:one,:baz]
+        ]).drop_left_level(2)).to eq(
+          Daru::Index.new([:bar, :baz])
+      )
+    end
   end
 
   context 'other forms of tuple list representation' do
@@ -540,12 +550,20 @@ describe Daru::MultiIndex do
       ])
     end
 
-    context "multiple indexes" do
-      subject { idx.subset :b, :one }
+    context "first level" do
+      subject { idx.subset :b }
 
       it { is_expected.to be_a described_class }
+      its(:size) { is_expected.to eq 4 }
+      its(:to_a) { is_expected.to eq [[:one, :bar], [:two, :bar], [:two, :baz], [:one, :foo]] }
+    end
+
+    context "first and second level" do
+      subject { idx.subset :b, :one }
+
+      it { is_expected.to be_a Daru::Index }
       its(:size) { is_expected.to eq 2 }
-      its(:to_a) { is_expected.to eq [[:bar], [:foo]] }
+      its(:to_a) { is_expected.to eq [:bar, :foo] }
     end
 
     context "multiple positional indexes" do

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -239,16 +239,14 @@ describe Daru::Vector do
               dtype: dtype, name: :sub_vector))
           end
 
-          it "returns sub vector when passed first and second layer of tuple" do
-            mi = Daru::MultiIndex.from_tuples([
-              [:foo],
-              [:bar]])
-            expect(@vector[:c,:two]).to eq(Daru::Vector.new([10,11], index: mi,
+          it "returns sub vector with simple index when passed first and second layer of tuple" do
+            i = Daru::Index.new([:foo, :bar])
+            expect(@vector[:c,:two]).to eq(Daru::Vector.new([10,11], index: i,
               dtype: dtype, name: :sub_sub_vector))
           end
 
           it "returns sub vector not a single element when passed the partial tuple" do
-            mi = Daru::MultiIndex.from_tuples([[:foo]])
+            mi = Daru::Index.new([:foo])
             expect(@vector[:d, :one]).to eq(Daru::Vector.new([12], index: mi,
               dtype: dtype, name: :sub_sub_vector))
           end


### PR DESCRIPTION
If you access a MultiIndexed Vector or DataFrame with a partial tuple that leaves one level remaining then the returned object should have s simple Daru::Index not a Daru::MultiIndex. This matches the behavior of Pandas