### PR TITLE
Add matrix in runtime dependencies

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   # it is required by NMatrix, yet we want to specify clearly which minimal version is OK
   spec.add_runtime_dependency 'packable', '~> 1.3.13'
+  spec.add_runtime_dependency 'matrix'
 
   spec.add_development_dependency 'spreadsheet', '~> 1.1.1'
   spec.add_development_dependency 'bundler', '>= 1.10'


### PR DESCRIPTION
`matrix` no longer be a standard library.